### PR TITLE
댓글 생성 요청 처리 기능 수정 #2

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ChangeListManager">
-    <list default="true" id="e8d2471e-421c-4917-bcc3-cffff1e072aa" name="Changes" comment="" />
+    <list default="true" id="fdddfbce-45df-4e49-ae25-5378e809d2d8" name="Changes" comment="" />
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -19,9 +19,9 @@
     <option name="stateVersion" value="1" />
   </component>
   <component name="ProjectColorInfo"><![CDATA[{
-  "associatedIndex": 2
+  "associatedIndex": 7
 }]]></component>
-  <component name="ProjectId" id="2bvfvxJPP4892QwjPbJR5VkqhxD" />
+  <component name="ProjectId" id="2bys6evSzbCnlxY99bNCW16Szm1" />
   <component name="ProjectViewState">
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
@@ -30,7 +30,7 @@
   "keyToString": {
     "RunOnceActivity.OpenProjectViewOnStart": "true",
     "RunOnceActivity.ShowReadmeOnStart": "true",
-    "git-widget-placeholder": "be-dev",
+    "git-widget-placeholder": "be/feat/#2",
     "kotlin-language-version-configured": "true",
     "last_opened_file_path": "/Users/admin/Desktop/Team3-33ma3"
   }
@@ -45,11 +45,11 @@
   <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
   <component name="TaskManager">
     <task active="true" id="Default" summary="Default task">
-      <changelist id="e8d2471e-421c-4917-bcc3-cffff1e072aa" name="Changes" comment="" />
-      <created>1707100707382</created>
+      <changelist id="fdddfbce-45df-4e49-ae25-5378e809d2d8" name="Changes" comment="" />
+      <created>1707198479546</created>
       <option name="number" value="Default" />
       <option name="presentableId" value="Default" />
-      <updated>1707100707382</updated>
+      <updated>1707198479546</updated>
     </task>
     <servers />
   </component>

--- a/33ma3/src/main/java/softeer/be33ma3/controller/OfferController.java
+++ b/33ma3/src/main/java/softeer/be33ma3/controller/OfferController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.*;
 import softeer.be33ma3.dto.request.OfferCreateDto;
 import softeer.be33ma3.dto.response.OfferDetailDto;
 import softeer.be33ma3.response.DataResponse;
+import softeer.be33ma3.response.SingleResponse;
 import softeer.be33ma3.service.OfferService;
 
 import java.util.List;
@@ -27,7 +28,7 @@ public class OfferController {
 
     @PostMapping("/{post_id}/offer")
     public ResponseEntity<?> createOffer(@PathVariable("post_id") Long postId, @RequestBody @Valid OfferCreateDto offerCreateDto) {
-        List<Object> createOfferResult = offerService.createOffer(postId, offerCreateDto);
-        return ResponseEntity.ok(DataResponse.success("입찰 성공", createOfferResult));
+        offerService.createOffer(postId, offerCreateDto);
+        return ResponseEntity.ok(SingleResponse.success("입찰 성공"));
     }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
@@ -8,6 +8,7 @@ import softeer.be33ma3.domain.Post;
 import softeer.be33ma3.dto.request.OfferCreateDto;
 import softeer.be33ma3.dto.response.OfferDetailDto;
 import softeer.be33ma3.dto.response.PostDetailDto;
+import softeer.be33ma3.repository.CenterRepository;
 import softeer.be33ma3.repository.OfferRepository;
 import softeer.be33ma3.repository.PostRepository;
 
@@ -20,6 +21,7 @@ public class OfferService {
     private final PostService postService;
     private final OfferRepository offerRepository;
     private final PostRepository postRepository;
+    private final CenterRepository centerRepository;
 
     // 견적 제시 댓글 하나 반환
     public OfferDetailDto getOneOffer(Long postId, Long offerId) {
@@ -31,19 +33,16 @@ public class OfferService {
     }
 
     // 견적 제시 댓글 생성
-    public List<Object> createOffer(Long postId, OfferCreateDto offerCreateDto) {
+    public void createOffer(Long postId, OfferCreateDto offerCreateDto) {
         // 1. 해당 게시글 가져오기
         Post post = postRepository.findById(postId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글"));
-        // TODO: 2. 센터 정보 가져오고 작성 가능한지 검증
+        // 2. 경매 완료된 게시글인지 검증
+        if(post.isDone())
+            throw new IllegalArgumentException("경매가 완료되었습니다.");
+        // TODO: 3. 센터 정보 가져오고 작성 가능한지 검증
         Center center = null;
         // 3. 댓글 생성하여 저장하기
         Offer offer = offerCreateDto.toEntity(post, center);
-        offer = offerRepository.save(offer);
-
-        // 4. 응답 객체 구축하기
-        PostDetailDto postDetailDto = PostDetailDto.fromEntity(post);
-        double priceAvg = postService.priceAvgOfPost(postId);
-        OfferDetailDto offerDetailDto = OfferDetailDto.fromEntity(offer);
-        return List.of(postDetailDto, priceAvg, offerDetailDto);
+        offerRepository.save(offer);
     }
 }


### PR DESCRIPTION
## 구현 내용
- [x] 해당 게시글이 경매 완료된 게시글인지 검증하는 단계 추가
- [x] 경매 완료된 게시글일 경우 새로운 댓글을 작성할 수 없도록 구현
- [x] 댓글 생성 성공 시 별다른 데이터 없이 성공 메세지만 반환

## 고민 사항

## 기타

로그인 구현 후 접근 유저 정보 검증 단계 구현 필요