### PR TITLE
게시글 세부사항 조회 기능 #3

### DIFF
--- a/33ma3/src/main/java/softeer/be33ma3/controller/OfferController.java
+++ b/33ma3/src/main/java/softeer/be33ma3/controller/OfferController.java
@@ -10,8 +10,6 @@ import softeer.be33ma3.response.DataResponse;
 import softeer.be33ma3.response.SingleResponse;
 import softeer.be33ma3.service.OfferService;
 
-import java.util.List;
-
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/post")

--- a/33ma3/src/main/java/softeer/be33ma3/controller/OfferController.java
+++ b/33ma3/src/main/java/softeer/be33ma3/controller/OfferController.java
@@ -20,7 +20,7 @@ public class OfferController {
     @GetMapping("/{post_id}/offer/{offer_id}")
     public ResponseEntity<?> getOneOffer(@PathVariable("post_id") Long postId,
                                          @PathVariable("offer_id") Long offerId) {
-        OfferDetailDto offerDetailDto = offerService.getOneOffer(postId, offerId);
+        OfferDetailDto offerDetailDto = offerService.getOffer(postId, offerId);
         return ResponseEntity.ok(DataResponse.success("견적 불러오기 성공", offerDetailDto));
     }
 

--- a/33ma3/src/main/java/softeer/be33ma3/controller/PostController.java
+++ b/33ma3/src/main/java/softeer/be33ma3/controller/PostController.java
@@ -3,13 +3,13 @@ package softeer.be33ma3.controller;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import softeer.be33ma3.dto.request.PostCreateDto;
+import softeer.be33ma3.response.DataResponse;
 import softeer.be33ma3.response.SingleResponse;
 import softeer.be33ma3.service.PostService;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -22,5 +22,11 @@ public class PostController {
         postService.createPost(postCreateDto);
 
         return ResponseEntity.ok().body(SingleResponse.success("게시글 작성 성공"));
+    }
+
+    @GetMapping("/{post_id}")
+    public ResponseEntity<?> getPost(@PathVariable("post_id") Long postId) {
+        List<Object> getPostResult = postService.getPost(postId);
+        return ResponseEntity.ok(DataResponse.success("게시글 조회 완료", getPostResult));
     }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/dto/response/PostDetailDto.java
+++ b/33ma3/src/main/java/softeer/be33ma3/dto/response/PostDetailDto.java
@@ -1,6 +1,7 @@
 package softeer.be33ma3.dto.response;
 
 import lombok.Builder;
+import softeer.be33ma3.domain.Image;
 import softeer.be33ma3.domain.Post;
 
 import java.time.LocalDateTime;
@@ -19,11 +20,13 @@ public class PostDetailDto {
     private String contents;
     private List<String> repairList;
     private List<String> tuneUpList;
+    private List<String> imageList;
 
     // Post Entity -> PostDetailDto 변환
     public static PostDetailDto fromEntity(Post post) {
         List<String> repairList = stringCommaParsing(post.getRepairService());
         List<String> tuneUpList = stringCommaParsing(post.getTuneUpService());
+        List<String> imageList = post.getImages().stream().map(Image::getLink).toList();
         int betweenTime = (int)ChronoUnit.DAYS.between(LocalDateTime.now(), post.getCreateTime());
         return PostDetailDto.builder()
                 .postId(post.getPostId())
@@ -34,7 +37,8 @@ public class PostDetailDto {
                 .regionName(post.getRegion().getRegionName())
                 .contents(post.getContents())
                 .repairList(repairList)
-                .tuneUpList(tuneUpList).build();
+                .tuneUpList(tuneUpList)
+                .imageList(imageList).build();
     }
 
     // 구분자 콤마로 문자열 파싱 후 각각의 토큰에서 공백 제거 후 리스트 반환

--- a/33ma3/src/main/java/softeer/be33ma3/dto/response/PostDetailDto.java
+++ b/33ma3/src/main/java/softeer/be33ma3/dto/response/PostDetailDto.java
@@ -3,6 +3,8 @@ package softeer.be33ma3.dto.response;
 import lombok.Builder;
 import softeer.be33ma3.domain.Post;
 
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.List;
 
@@ -11,7 +13,8 @@ public class PostDetailDto {
     private Long postId;
     private String carType;
     private String modelName;
-    private int deadLine;
+    private int dDay;
+    private LocalDateTime serverTime;
     private String regionName;
     private String contents;
     private List<String> repairList;
@@ -21,11 +24,13 @@ public class PostDetailDto {
     public static PostDetailDto fromEntity(Post post) {
         List<String> repairList = stringCommaParsing(post.getRepairService());
         List<String> tuneUpList = stringCommaParsing(post.getTuneUpService());
+        int betweenTime = (int)ChronoUnit.DAYS.between(LocalDateTime.now(), post.getCreateTime());
         return PostDetailDto.builder()
                 .postId(post.getPostId())
                 .carType(post.getCarType())
                 .modelName(post.getModelName())
-                .deadLine(post.getDeadline())
+                .dDay(post.getDeadline() - betweenTime)
+                .serverTime(LocalDateTime.now())
                 .regionName(post.getRegion().getRegionName())
                 .contents(post.getContents())
                 .repairList(repairList)

--- a/33ma3/src/main/java/softeer/be33ma3/repository/CenterRepository.java
+++ b/33ma3/src/main/java/softeer/be33ma3/repository/CenterRepository.java
@@ -3,5 +3,9 @@ package softeer.be33ma3.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import softeer.be33ma3.domain.Center;
 
+import java.util.Optional;
+
 public interface CenterRepository extends JpaRepository<Center, Long> {
+
+    Optional<Center> findByMember_MemberId(Long memberId);
 }

--- a/33ma3/src/main/java/softeer/be33ma3/repository/OfferRepository.java
+++ b/33ma3/src/main/java/softeer/be33ma3/repository/OfferRepository.java
@@ -4,7 +4,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import softeer.be33ma3.domain.Offer;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface OfferRepository extends JpaRepository<Offer, Long> {
     List<Offer> findByPost_PostId(Long postId);
+    Optional<Offer> findByCenter_CenterId(Long centerId);
 }

--- a/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
@@ -23,7 +23,7 @@ public class OfferService {
     private final CenterRepository centerRepository;
 
     // 견적 제시 댓글 하나 반환
-    public OfferDetailDto getOneOffer(Long postId, Long offerId) {
+    public OfferDetailDto getOffer(Long postId, Long offerId) {
         // 1. 해당하는 게시글 가져와 존재하는지 판단하기
         Post post = postRepository.findById(postId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글"));
         // 2. 해당하는 댓글 가져와 존재하는지 판단하기

--- a/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
@@ -2,20 +2,19 @@ package softeer.be33ma3.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import softeer.be33ma3.domain.Center;
 import softeer.be33ma3.domain.Offer;
 import softeer.be33ma3.domain.Post;
 import softeer.be33ma3.dto.request.OfferCreateDto;
 import softeer.be33ma3.dto.response.OfferDetailDto;
-import softeer.be33ma3.dto.response.PostDetailDto;
 import softeer.be33ma3.repository.CenterRepository;
 import softeer.be33ma3.repository.OfferRepository;
 import softeer.be33ma3.repository.PostRepository;
 
-import java.util.List;
-
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class OfferService {
 
     private final PostService postService;
@@ -33,6 +32,7 @@ public class OfferService {
     }
 
     // 견적 제시 댓글 생성
+    @Transactional
     public void createOffer(Long postId, OfferCreateDto offerCreateDto) {
         // 1. 해당 게시글 가져오기
         Post post = postRepository.findById(postId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글"));


### PR DESCRIPTION
## 구현 내용
- 경매 완료된 게시글 or 글 작성자의 접근인 경우: 게시글 세부사항 + 해당 게시글에 속해있는 모든 댓글 목록 반환
- 경매 진행중 and 글 작성자가 아닌 유저의 접근인 경우: 게시글 세부사항 + 해당 시점까지의 평균 견적 제시 가격 반환
- 해당 게시글에 견적 제시 댓글을 작성한 유저의 접근인 경우, 추가로 본인이 작성한 댓글 세부사항도 포함하여 반환 

## 고민 사항
어떤 유저냐에 따라 보여지는 화면 구성이 다르다보니 가능한 모든 경우를 고려하기 위해 오래 고민하였음.
프론트 쪽이 반환 데이터의 필드명을 보고 어떤 데이터인지를 쉽게 파악할 수 있도록 반환 객체 필드 네이밍을 고민하였음.

## 기타
