### PR TITLE
견적 제시 댓글 수정 기능 #58

### DIFF
--- a/33ma3/src/main/java/softeer/be33ma3/controller/OfferController.java
+++ b/33ma3/src/main/java/softeer/be33ma3/controller/OfferController.java
@@ -35,9 +35,9 @@ public class OfferController {
     @Parameter(name = "offer_id", description = "offer id", required = true, example = "2", in = ParameterIn.PATH)
     @Operation(summary = "견적 댓글 불러오기", description = "견적 댓글 불러오기 메서드 입니다.")
     @GetMapping("/{post_id}/offer/{offer_id}")
-    public ResponseEntity<?> getOneOffer(@PathVariable("post_id") Long postId,
+    public ResponseEntity<?> showOffer(@PathVariable("post_id") Long postId,
                                          @PathVariable("offer_id") Long offerId) {
-        OfferDetailDto offerDetailDto = offerService.getOffer(postId, offerId);
+        OfferDetailDto offerDetailDto = offerService.showOffer(postId, offerId);
         return ResponseEntity.ok(DataResponse.success("견적 불러오기 성공", offerDetailDto));
     }
 

--- a/33ma3/src/main/java/softeer/be33ma3/controller/OfferController.java
+++ b/33ma3/src/main/java/softeer/be33ma3/controller/OfferController.java
@@ -56,4 +56,24 @@ public class OfferController {
         offerService.sendOfferList2Writer(postId);
         return ResponseEntity.ok(SingleResponse.success("입찰 성공"));
     }
+
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "댓글 수정 성공", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
+            @ApiResponse(responseCode = "401", description = "작성자만 수정 가능합니다.", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
+            @ApiResponse(responseCode = "400", description = "기존 금액보다 낮은 금액으로만 수정 가능합니다."
+                    + "<br>존재하지 않는 게시글" + "<br>완료된 게시글" + "<br>존재하지 않는 견적",
+                    content = @Content(schema = @Schema(implementation = SingleResponse.class)))
+    })
+    @Parameter(name = "post_id", description = "게시글 id", required = true, example = "1", in = ParameterIn.PATH)
+    @Parameter(name = "offer_id", description = "offer id", required = true, example = "2", in = ParameterIn.PATH)
+    @Operation(summary = "견적 댓글 수정하기", description = "견적 댓글 수정하기 메서드 입니다.")
+    @PatchMapping("/{post_id}/offer/{offer_id}")
+    public ResponseEntity<?> updateOffer(@PathVariable("post_id") Long postId,
+                                         @PathVariable("offer_id") Long offerId,
+                                         @RequestBody OfferCreateDto offerCreateDto) {
+        offerService.updateOffer(postId, offerId, offerCreateDto);
+        // 글 작성자에게 업데이트 된 댓글 리스트 보내기
+        offerService.sendOfferList2Writer(postId);
+        return ResponseEntity.ok(SingleResponse.success("댓글 수정 성공"));
+    }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/controller/OfferController.java
+++ b/33ma3/src/main/java/softeer/be33ma3/controller/OfferController.java
@@ -54,6 +54,8 @@ public class OfferController {
         offerService.createOffer(postId, offerCreateDto);
         // 글 작성자에게 업데이트 된 댓글 리스트 보내기
         offerService.sendOfferList2Writer(postId);
+        // 댓글 작성자들에게 업데이트된 평균 견적 제시 가격 보내기
+        offerService.sendAvgPrice2Centers(postId);
         return ResponseEntity.ok(SingleResponse.success("입찰 성공"));
     }
 
@@ -74,6 +76,8 @@ public class OfferController {
         offerService.updateOffer(postId, offerId, offerCreateDto);
         // 글 작성자에게 업데이트 된 댓글 리스트 보내기
         offerService.sendOfferList2Writer(postId);
+        // 댓글 작성자들에게 업데이트된 평균 견적 제시 가격 보내기
+        offerService.sendAvgPrice2Centers(postId);
         return ResponseEntity.ok(SingleResponse.success("댓글 수정 성공"));
     }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/controller/PostController.java
+++ b/33ma3/src/main/java/softeer/be33ma3/controller/PostController.java
@@ -47,8 +47,8 @@ public class PostController {
     @Operation(summary = "게시글 조회", description = "게시글 조회 메서드 입니다.")
     @Parameter(name = "post_id", description = "조회할 게시글 id", required = true, example = "1", in = ParameterIn.PATH)
     @GetMapping("/{post_id}")
-    public ResponseEntity<?> getPost(@PathVariable("post_id") Long postId) {
-        List<Object> getPostResult = postService.getPost(postId);
+    public ResponseEntity<?> showPost(@PathVariable("post_id") Long postId) {
+        List<Object> getPostResult = postService.showPost(postId);
         return ResponseEntity.ok(DataResponse.success("게시글 조회 완료", getPostResult));
     }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/controller/PostController.java
+++ b/33ma3/src/main/java/softeer/be33ma3/controller/PostController.java
@@ -41,7 +41,7 @@ public class PostController {
 
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "게시글 조회 완료", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
-            @ApiResponse(responseCode = "400", description = "존재하지 않는 게시글" + "<br>존재하지 않는 서비스 센터" + "<br>견적 제시 댓글이 없습니다.",
+            @ApiResponse(responseCode = "400", description = "존재하지 않는 게시글" + "<br>존재하지 않는 서비스 센터",
                     content = @Content(schema = @Schema(implementation = SingleResponse.class)))
     })
     @Operation(summary = "게시글 조회", description = "게시글 조회 메서드 입니다.")

--- a/33ma3/src/main/java/softeer/be33ma3/domain/Offer.java
+++ b/33ma3/src/main/java/softeer/be33ma3/domain/Offer.java
@@ -35,4 +35,14 @@ public class Offer {
         this.post = post;
         this.center = center;
     }
+
+    public void setPrice(int price) {
+        this.price = price;
+    }
+    public void setContents(String contents) {
+        this.contents = contents;
+    }
+    public void setSelected(boolean selected) {
+        this.selected = selected;
+    }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/dto/request/PostCreateDto.java
+++ b/33ma3/src/main/java/softeer/be33ma3/dto/request/PostCreateDto.java
@@ -31,6 +31,7 @@ public class PostCreateDto {
 
     @Schema(description = "마감기한", example = "2")
     @NotNull(message = "마감기한은 필수입니다.")
+    @Min(value = 1,message = "최소 1일 이상 선택해야 합니다.")
     @Max(value = 10, message = "최대 10일까지 가능합니다.")
     private Integer deadline;
 

--- a/33ma3/src/main/java/softeer/be33ma3/dto/response/OfferDetailDto.java
+++ b/33ma3/src/main/java/softeer/be33ma3/dto/response/OfferDetailDto.java
@@ -47,22 +47,22 @@ public class OfferDetailDto implements Comparable<OfferDetailDto> {
 
     // List<Offer> -> List<OfferDetailDto> 변환
     public static List<OfferDetailDto> fromEntityList(List<Offer> offerList) {
+        // offer -> offerDetailDto로 변환
         List<OfferDetailDto> offerDetailList = offerList.stream()
                 .map(OfferDetailDto::fromEntity)
                 .toList();
-        Collections.sort(offerDetailList);      // 정렬
+        // 댓글 목록 정렬
+        Collections.sort(offerDetailList);
 
-        // 낙찰된 견적이 있는지 확인
-        OfferDetailDto selected = offerDetailList.stream()
+        // 낙찰된 견적이 있다면 첫 번째 순서로 보내기
+        offerDetailList.stream()
                 .filter(OfferDetailDto::isSelected)
                 .findFirst()
-                .orElse(null);
+                .ifPresent(target -> {
+                    offerDetailList.remove(target);
+                    offerDetailList.add(0, target);
+                });
 
-        // 선택된 요소를 리스트에서 제거하고 맨 앞으로 이동시킵니다.
-        if (selected != null) {
-            offerDetailList.remove(selected);
-            offerDetailList.add(0, selected);
-        }
         return offerDetailList;
     }
 

--- a/33ma3/src/main/java/softeer/be33ma3/dto/response/OfferDetailDto.java
+++ b/33ma3/src/main/java/softeer/be33ma3/dto/response/OfferDetailDto.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import softeer.be33ma3.domain.Offer;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -48,9 +49,10 @@ public class OfferDetailDto implements Comparable<OfferDetailDto> {
     // List<Offer> -> List<OfferDetailDto> 변환
     public static List<OfferDetailDto> fromEntityList(List<Offer> offerList) {
         // offer -> offerDetailDto로 변환
-        List<OfferDetailDto> offerDetailList = offerList.stream()
+        List<OfferDetailDto> offerDetailList = new ArrayList<>(
+                offerList.stream()
                 .map(OfferDetailDto::fromEntity)
-                .toList();
+                .toList());
         // 댓글 목록 정렬
         Collections.sort(offerDetailList);
 

--- a/33ma3/src/main/java/softeer/be33ma3/dto/response/OfferDetailDto.java
+++ b/33ma3/src/main/java/softeer/be33ma3/dto/response/OfferDetailDto.java
@@ -50,8 +50,19 @@ public class OfferDetailDto implements Comparable<OfferDetailDto> {
         List<OfferDetailDto> offerDetailList = offerList.stream()
                 .map(OfferDetailDto::fromEntity)
                 .toList();
-        Collections.sort(offerDetailList);
+        Collections.sort(offerDetailList);      // 정렬
 
+        // 낙찰된 견적이 있는지 확인
+        OfferDetailDto selected = offerDetailList.stream()
+                .filter(OfferDetailDto::isSelected)
+                .findFirst()
+                .orElse(null);
+
+        // 선택된 요소를 리스트에서 제거하고 맨 앞으로 이동시킵니다.
+        if (selected != null) {
+            offerDetailList.remove(selected);
+            offerDetailList.add(0, selected);
+        }
         return offerDetailList;
     }
 

--- a/33ma3/src/main/java/softeer/be33ma3/dto/response/PostDetailDto.java
+++ b/33ma3/src/main/java/softeer/be33ma3/dto/response/PostDetailDto.java
@@ -5,7 +5,9 @@ import lombok.Builder;
 import softeer.be33ma3.domain.Image;
 import softeer.be33ma3.domain.Post;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.List;
@@ -25,8 +27,8 @@ public class PostDetailDto {
     @Schema(description = "남은 기한", example = "3")
     private int dDay;
 
-    @Schema(description = "서버 시간", example = "2024-02-06T02:23:25.012345")
-    private LocalDateTime serverTime;
+    @Schema(description = "당일 남은 시간", example = "11:32:51")
+    private LocalTime remainTime;
 
     @Schema(description = "지역 명", example = "강남구")
     private String regionName;
@@ -49,13 +51,14 @@ public class PostDetailDto {
         List<String> tuneUpList = stringCommaParsing(post.getTuneUpService());
         List<String> imageList = post.getImages().stream().map(Image::getLink).toList();
         int betweenTime = (int)ChronoUnit.DAYS.between(LocalDateTime.now(), post.getCreateTime());
+        LocalTime remainTime = calculateRemainTime(post.getCreateTime());
 
         return PostDetailDto.builder()
                 .postId(post.getPostId())
                 .carType(post.getCarType())
                 .modelName(post.getModelName())
                 .dDay(post.getDeadline() - betweenTime)
-                .serverTime(LocalDateTime.now())
+                .remainTime(remainTime)
                 .regionName(post.getRegion().getRegionName())
                 .contents(post.getContents())
                 .repairList(repairList)
@@ -68,5 +71,11 @@ public class PostDetailDto {
         return Arrays.stream(inputString.split(","))
                 .map(String::strip)
                 .toList();
+    }
+
+    // 글 생성 시간과 현재 시간을 비교하여 남은 시간:분:초를 반환
+    private static LocalTime calculateRemainTime(LocalDateTime createTime) {
+        Duration duration = Duration.between(createTime, LocalDateTime.now());
+        return LocalTime.of((int)duration.toHours(), (int)duration.toMinutes()%60, (int)duration.toSeconds()%60);
     }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/exception/ControllerAdvice.java
+++ b/33ma3/src/main/java/softeer/be33ma3/exception/ControllerAdvice.java
@@ -20,6 +20,11 @@ public class ControllerAdvice {
         return ResponseEntity.badRequest().body(SingleResponse.error(e.getMessage()));
     }
 
+    @ExceptionHandler(UnauthorizedException.class)
+    public ResponseEntity<?> unauthorized(UnauthorizedException e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(SingleResponse.error(e.getMessage()));
+    }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<?> InternalServerError(Exception e) {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(SingleResponse.error(e.getMessage()));

--- a/33ma3/src/main/java/softeer/be33ma3/exception/ControllerAdvice.java
+++ b/33ma3/src/main/java/softeer/be33ma3/exception/ControllerAdvice.java
@@ -15,7 +15,7 @@ public class ControllerAdvice {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(SingleResponse.error(e.getFieldError().getDefaultMessage()));
     }
   
-    @ExceptionHandler({IllegalArgumentException.class, ArithmeticException.class})
+    @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<?> badRequest(RuntimeException e) {
         return ResponseEntity.badRequest().body(SingleResponse.error(e.getMessage()));
     }

--- a/33ma3/src/main/java/softeer/be33ma3/exception/UnauthorizedException.java
+++ b/33ma3/src/main/java/softeer/be33ma3/exception/UnauthorizedException.java
@@ -1,0 +1,8 @@
+package softeer.be33ma3.exception;
+
+public class UnauthorizedException extends RuntimeException {
+
+    public UnauthorizedException(String message) {
+        super(message);
+    }
+}

--- a/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
@@ -98,4 +98,18 @@ public class OfferService {
         // 4. 전송하기
         webSocketHandler.sendData2Client(memberId, offerDetailList);
     }
+
+    // 게시글에 견적을 작성한 모든 서비스 센터들에게 평균 견적 제시 가격 실시간 전송
+    public void sendAvgPrice2Centers(Long postId) {
+        // 1. 해당 게시글에 달린 모든 견적 가져오기
+        List<Offer> offerList = offerRepository.findByPost_PostId(postId);
+        // 2. 견적 작성자의 member id 가져오기
+        List<Long> memberList = offerList.stream()
+                .map(offer -> offer.getCenter().getMember().getMemberId())
+                .toList();
+        // 3. 평균 견적 가격 계산하기
+        double AvgPrice = calculatePriceAvg(offerList);
+        // 4. 전송하기
+        memberList.forEach(memberId -> webSocketHandler.sendData2Client(memberId, AvgPrice));
+    }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
@@ -81,8 +81,6 @@ public class OfferService {
 
         if(stats.getSum() == 0)
             return 0;
-        if(stats.getCount() == 0)
-            throw new ArithmeticException("견적 제시 댓글이 없습니다.");
         return stats.getAverage();
     }
 

--- a/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
@@ -24,7 +24,7 @@ public class OfferService {
     private final WebSocketHandler webSocketHandler;
 
     // 견적 제시 댓글 하나 반환
-    public OfferDetailDto getOffer(Long postId, Long offerId) {
+    public OfferDetailDto showOffer(Long postId, Long offerId) {
         // 1. 해당 게시글 가져오기
         Post post = postRepository.findById(postId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글"));
         // 2. 해당 댓글 가져오기

--- a/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
@@ -73,8 +73,8 @@ public class OfferService {
         offerRepository.save(offer);
     }
 
-    // 견적 제시 댓글 목록의 평균 제시 가격 게산하여 반환하기
-    public static double calculatePriceAvg(List<Offer> offerList) {
+    // 견적 제시 댓글 목록의 평균 제시 가격 계산하여 반환하기
+    public static double calculateAvgPrice(List<Offer> offerList) {
         // 제시 가격의 합계, 개수 구하기
         IntSummaryStatistics stats = offerList.stream()
                 .collect(Collectors.summarizingInt(Offer::getPrice));
@@ -108,8 +108,8 @@ public class OfferService {
                 .map(offer -> offer.getCenter().getMember().getMemberId())
                 .toList();
         // 3. 평균 견적 가격 계산하기
-        double AvgPrice = calculatePriceAvg(offerList);
+        double avgPrice = calculateAvgPrice(offerList);
         // 4. 전송하기
-        memberList.forEach(memberId -> webSocketHandler.sendData2Client(memberId, AvgPrice));
+        memberList.forEach(memberId -> webSocketHandler.sendData2Client(memberId, avgPrice));
     }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
@@ -89,10 +89,10 @@ public class PostService {
         // 3-2. 경매가 진행 중이고 작성자가 아닌 유저의 접근일 경우
         // 해당 게시글의 견적 모두 가져오기
         List<Offer> offerList = offerRepository.findByPost_PostId(postId);
-        double priceAvg = OfferService.calculatePriceAvg(offerList);
+        double avgPrice = OfferService.calculateAvgPrice(offerList);
         // 견적을 작성한 이력이 있는 서비스 센터의 접근일 경우 작성한 견적 가져오기
         OfferDetailDto offerDetailDto = getCenterOffer(postId, member.get());
-        return List.of(postDetailDto, priceAvg, offerDetailDto);
+        return List.of(postDetailDto, avgPrice, offerDetailDto);
     }
 
     // 멤버 정보를 이용하여 견적을 작성한 이력이 있는 서비스 센터일 경우 작성한 견적 반환

--- a/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
@@ -72,7 +72,7 @@ public class PostService {
     }
 
     // 게시글 세부사항 반환 (로그인 하지 않아도 확인 가능)
-    public List<Object> getPost(Long postId) {
+    public List<Object> showPost(Long postId) {
         // 1. 게시글 존재 유무 판단
         Post post = postRepository.findById(postId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글"));
         // 2. 게시글 세부 사항 가져오기

--- a/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
@@ -87,26 +87,12 @@ public class PostService {
             return List.of(postDetailDto, offerDetailList);
         }
         // 3-2. 경매가 진행 중이고 작성자가 아닌 유저의 접근일 경우
-        double priceAvg = priceAvgOfPost(postId);
+        // 해당 게시글의 견적 모두 가져오기
+        List<Offer> offerList = offerRepository.findByPost_PostId(postId);
+        double priceAvg = OfferService.calculatePriceAvg(offerList);
         // 견적을 작성한 이력이 있는 서비스 센터의 접근일 경우 작성한 견적 가져오기
         OfferDetailDto offerDetailDto = getCenterOffer(postId, member.get());
         return List.of(postDetailDto, priceAvg, offerDetailDto);
-    }
-
-    // 해당 게시글의 평균 견적 제시 가격 반환
-    private double priceAvgOfPost(Long postId) {
-        // 해당 게시글의 견적 모두 가져오기
-        List<Offer> offerList = offerRepository.findByPost_PostId(postId);
-
-        // 제시 가격의 합계, 개수 구하기
-        IntSummaryStatistics stats = offerList.stream()
-                .collect(Collectors.summarizingInt(Offer::getPrice));
-
-        if(stats.getSum() == 0)
-            return 0;
-        if(stats.getCount() == 0)
-            throw new ArithmeticException("견적 제시 댓글이 없습니다.");
-        return stats.getAverage();
     }
 
     // 멤버 정보를 이용하여 견적을 작성한 이력이 있는 서비스 센터일 경우 작성한 견적 반환

--- a/33ma3/src/main/java/softeer/be33ma3/service/WebSocketService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/WebSocketService.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
+import softeer.be33ma3.dto.request.PostCreateDto;
 import softeer.be33ma3.repository.WebSocketRepository;
 
 import java.io.IOException;


### PR DESCRIPTION
## 구현 내용
- [x] 타겟이 되는 게시글 및 댓글이 존재하는지 검증
- [x] 기존 댓글 작성자의 접근인지 검증
- [x] 수정 권한이 없을 경우 401 상태코드를 던지기 위한 UnauthorizedException 클래스 생성
- [x] 기존 댓글의 제시 가격 이하의 가격으로 수정되었는지 검증
- [x] 댓글 생성, 수정 시 서비스 센터들에게도 실시간으로 평균 견적 제시 가격을 보내는 기능 추가

## 고민 사항
평균 견적 제시 가격을 계산하는 메소드가 PostService에 있어서, OfferService에서 사용하지 못하는 문제가 있었다.
예전에도 비슷한 문제가 있었던 만큼, 아예 List<Offer>를 파라미터로 받는 것으로 변경하여 해당 메소드를 OfferService 내의 정적 메소드로 두었다.
## 기타