### PR TITLE
견적 제시 댓글 삭제 구현 #65

### DIFF
--- a/33ma3/src/main/java/softeer/be33ma3/controller/OfferController.java
+++ b/33ma3/src/main/java/softeer/be33ma3/controller/OfferController.java
@@ -80,4 +80,24 @@ public class OfferController {
         offerService.sendAvgPrice2Centers(postId);
         return ResponseEntity.ok(SingleResponse.success("댓글 수정 성공"));
     }
+
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "댓글 삭제 성공", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
+            @ApiResponse(responseCode = "401", description = "작성자만 삭제 가능합니다.", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
+            @ApiResponse(responseCode = "400", description = "존재하지 않는 게시글" + "<br>완료된 게시글" + "<br>존재하지 않는 견적",
+                    content = @Content(schema = @Schema(implementation = SingleResponse.class)))
+    })
+    @Parameter(name = "post_id", description = "게시글 id", required = true, example = "1", in = ParameterIn.PATH)
+    @Parameter(name = "offer_id", description = "offer id", required = true, example = "2", in = ParameterIn.PATH)
+    @Operation(summary = "견적 댓글 삭제하기", description = "견적 댓글 수정하기 메서드 입니다.")
+    @DeleteMapping("/{post_id}/offer/{offer_id}")
+    public ResponseEntity<?> deleteOffer(@PathVariable("post_id") Long postId,
+                                         @PathVariable("offer_id") Long offerId) {
+        offerService.deleteOffer(postId, offerId);
+        // 글 작성자에게 업데이트 된 댓글 리스트 보내기
+        offerService.sendOfferList2Writer(postId);
+        // 댓글 작성자들에게 업데이트된 평균 견적 제시 가격 보내기
+        offerService.sendAvgPrice2Centers(postId);
+        return ResponseEntity.ok(SingleResponse.success("댓글 삭제 성공"));
+    }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
@@ -73,6 +73,24 @@ public class OfferService {
         offerRepository.save(offer);
     }
 
+    // 견적 제시 댓글 삭제
+    public void deleteOffer(Long postId, Long offerId) {
+        // 1. 해당 게시글 가져오기
+        Post post = postRepository.findById(postId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글"));
+        // 2. 경매 완료된 게시글인지 검증
+        if(post.isDone())
+            throw new IllegalArgumentException("완료된 게시글");
+        // TODO: 3. 센터 정보 가져오기
+        Center center = null;
+        // 4. 기존 댓글 가져오기
+        Offer offer = offerRepository.findById(offerId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 견적"));
+        // 5. 댓글 작성자인지 검증
+        if(center.getCenterId() != offer.getCenter().getCenterId())
+            throw new UnauthorizedException("작성자만 삭제 가능합니다.");
+        // 6. 댓글 삭제하기
+        offerRepository.delete(offer);
+    }
+
     // 견적 제시 댓글 목록의 평균 제시 가격 계산하여 반환하기
     public static double calculateAvgPrice(List<Offer> offerList) {
         // 제시 가격의 합계, 개수 구하기


### PR DESCRIPTION
## 구현 내용
- [x] 게시글 존재 여부 검증
- [x] 경매 진행 중인 게시글에서만 삭제 가능하도록 구현
- [x] 댓글 존재 여부 검증
- [x] 댓글 작성자인지 검증
- [x] 성공적인 댓글 삭제 시 게시글 작성자에게 업데이트 된 댓글 목록 실시간 전송, 해당 글에 댓글을 작성한 모든 서비스 센터들에게 평균 제시 가격 전송

## 고민 사항
## 기타
로그인 기능 완료 시 댓글 작성자 검증 단계 기능 추가 구현할 예정