### PR TITLE
게시물 수정, 삭제 기능 구현 #83 #84

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,13 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="AutoImportSettings">
-    <option name="autoReloadType" value="SELECTIVE" />
-  </component>
   <component name="ChangeListManager">
-    <list default="true" id="0405377e-4151-4a4a-b097-72fe63567a5f" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/33ma3/src/main/java/softeer/be33ma3/config/WebConfig.java" beforeDir="false" afterPath="$PROJECT_DIR$/33ma3/src/main/java/softeer/be33ma3/config/WebConfig.java" afterDir="false" />
-    </list>
+    <list default="true" id="1290e3c2-1d6a-4b4e-afb2-c7e48720b9aa" name="Changes" comment="" />
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -25,12 +19,10 @@
     <option name="stateVersion" value="1" />
   </component>
   <component name="ProjectColorInfo"><![CDATA[{
+  "customColor": "",
   "associatedIndex": 1
 }]]></component>
-  <component name="ProjectId" id="2cBJBzzaGeHjBeyOksrFjqcucTT" />
-  <component name="ProjectLevelVcsManager">
-    <ConfirmationsSetting value="1" id="Add" />
-  </component>
+  <component name="ProjectId" id="2cIKLJoeVCJzqxwtZl4OXaxOOar" />
   <component name="ProjectViewState">
     <option name="showLibraryContents" value="true" />
   </component>
@@ -38,13 +30,9 @@
   "keyToString": {
     "RunOnceActivity.OpenProjectViewOnStart": "true",
     "RunOnceActivity.ShowReadmeOnStart": "true",
-    "git-widget-placeholder": "be/feat/aws",
+    "git-widget-placeholder": "be/feat/#83",
     "kotlin-language-version-configured": "true",
     "last_opened_file_path": "/Users/admin/Desktop/Team3-33ma3",
-    "node.js.detected.package.eslint": "true",
-    "node.js.detected.package.tslint": "true",
-    "node.js.selected.package.eslint": "(autodetect)",
-    "node.js.selected.package.tslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",
     "vue.rearranger.settings.migration": "true"
   }
@@ -59,27 +47,16 @@
   <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
   <component name="TaskManager">
     <task active="true" id="Default" summary="Default task">
-      <changelist id="0405377e-4151-4a4a-b097-72fe63567a5f" name="Changes" comment="" />
-      <created>1707578907670</created>
+      <changelist id="1290e3c2-1d6a-4b4e-afb2-c7e48720b9aa" name="Changes" comment="" />
+      <created>1707793597168</created>
       <option name="number" value="Default" />
       <option name="presentableId" value="Default" />
-      <updated>1707578907670</updated>
-      <workItem from="1707578909174" duration="1742000" />
+      <updated>1707793597168</updated>
+      <workItem from="1707793600392" duration="116000" />
     </task>
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
     <option name="version" value="3" />
-  </component>
-  <component name="Vcs.Log.Tabs.Properties">
-    <option name="TAB_STATES">
-      <map>
-        <entry key="MAIN">
-          <value>
-            <State />
-          </value>
-        </entry>
-      </map>
-    </option>
   </component>
 </project>

--- a/33ma3/src/main/java/softeer/be33ma3/controller/PostController.java
+++ b/33ma3/src/main/java/softeer/be33ma3/controller/PostController.java
@@ -32,7 +32,8 @@ public class PostController {
     private final PostService postService;
 
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "게시글 작성 성공", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
+            @ApiResponse(responseCode = "200", description = "게시글 작성 성공", content = @Content(schema = @Schema(implementation = DataResponse.class))),
+            @ApiResponse(responseCode = "401", description = "센터는 글 작성이 불가능합니다.", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
             @ApiResponse(responseCode = "400", description = "존재하지 않는 게시글" + "<br>존재하지 않는 회원" + "<br>존재하지 않는 구",
                     content = @Content(schema = @Schema(implementation = SingleResponse.class)))
     })

--- a/33ma3/src/main/java/softeer/be33ma3/controller/PostController.java
+++ b/33ma3/src/main/java/softeer/be33ma3/controller/PostController.java
@@ -57,4 +57,18 @@ public class PostController {
         List<Object> getPostResult = postService.showPost(postId, member);
         return ResponseEntity.ok(DataResponse.success("게시글 조회 완료", getPostResult));
     }
+
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "게시글 삭제 성공", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
+            @ApiResponse(responseCode = "401", description = "작성자만 가능합니다.", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
+            @ApiResponse(responseCode = "400", description = "존재하지 않는 게시글" + "<br>존재하지 않는 회원" + "<br>경매 시작 전에만 가능합니다.", content = @Content(schema = @Schema(implementation = SingleResponse.class)))
+    })
+    @Operation(summary = "게시글 삭제", description = "게시글 삭제 메서드 입니다.")
+    @Parameter(name = "post_id", description = "수정할 게시글 id", required = true, example = "1", in = ParameterIn.PATH)
+    @PutMapping("/{post_id}")
+    public ResponseEntity<?> editPost(@Schema(hidden = true) @CurrentUser Member member,  @PathVariable("post_id") Long postId, @RequestBody PostCreateDto postCreateDto){
+        postService.editPost(member, postId, postCreateDto);
+
+        return ResponseEntity.ok().body(SingleResponse.success("게시글 수정 성공"));
+    }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/controller/PostController.java
+++ b/33ma3/src/main/java/softeer/be33ma3/controller/PostController.java
@@ -39,9 +39,9 @@ public class PostController {
     @Operation(summary = "게시글 작성", description = "게시글 작성 메서드 입니다.")
     @PostMapping(value = "/create", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE})
     public ResponseEntity<?> createPost(@Schema(hidden = true) @CurrentUser Member member, @RequestPart(name = "images") List<MultipartFile> images, @RequestPart(name = "request") PostCreateDto postCreateDto){
-        postService.createPost(member,postCreateDto, images);
+        Long postId = postService.createPost(member,postCreateDto, images);
 
-        return ResponseEntity.ok().body(SingleResponse.success("게시글 작성 성공"));
+        return ResponseEntity.ok().body(DataResponse.success("게시글 작성 성공", postId));
     }
 
     @ApiResponses({

--- a/33ma3/src/main/java/softeer/be33ma3/controller/PostController.java
+++ b/33ma3/src/main/java/softeer/be33ma3/controller/PostController.java
@@ -59,16 +59,30 @@ public class PostController {
     }
 
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "게시글 삭제 성공", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
+            @ApiResponse(responseCode = "200", description = "게시글 수정 성공", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
             @ApiResponse(responseCode = "401", description = "작성자만 가능합니다.", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
             @ApiResponse(responseCode = "400", description = "존재하지 않는 게시글" + "<br>존재하지 않는 회원" + "<br>경매 시작 전에만 가능합니다.", content = @Content(schema = @Schema(implementation = SingleResponse.class)))
     })
-    @Operation(summary = "게시글 삭제", description = "게시글 삭제 메서드 입니다.")
+    @Operation(summary = "게시글 수정", description = "게시글 수정 메서드 입니다.")
     @Parameter(name = "post_id", description = "수정할 게시글 id", required = true, example = "1", in = ParameterIn.PATH)
     @PutMapping("/{post_id}")
     public ResponseEntity<?> editPost(@Schema(hidden = true) @CurrentUser Member member,  @PathVariable("post_id") Long postId, @RequestBody PostCreateDto postCreateDto){
         postService.editPost(member, postId, postCreateDto);
 
         return ResponseEntity.ok().body(SingleResponse.success("게시글 수정 성공"));
+    }
+
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "게시글 삭제 성공", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
+            @ApiResponse(responseCode = "401", description = "작성자만 가능합니다.", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
+            @ApiResponse(responseCode = "400", description = "존재하지 않는 게시글" + "<br>존재하지 않는 회원" + "<br>경매 시작 전에만 가능합니다.", content = @Content(schema = @Schema(implementation = SingleResponse.class)))
+    })
+    @Operation(summary = "게시글 삭제", description = "게시글 삭제 메서드 입니다.")
+    @Parameter(name = "post_id", description = "삭제할 게시글 id", required = true, example = "1", in = ParameterIn.PATH)
+    @DeleteMapping("/{post_id}")
+    public ResponseEntity<?> deletePost(@Schema(hidden = true) @CurrentUser Member member, @PathVariable("post_id") Long postId){
+        postService.deletePost(member, postId);
+
+        return ResponseEntity.ok().body(SingleResponse.success("게시글 삭제 성공"));
     }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/domain/Image.java
+++ b/33ma3/src/main/java/softeer/be33ma3/domain/Image.java
@@ -15,6 +15,8 @@ public class Image {
 
     private String link;
 
+    private String fileName;
+
     @ManyToOne
     @JoinColumn(name = "post_id")
     private Post post;
@@ -24,9 +26,10 @@ public class Image {
         post.getImages().add(this);
     }
 
-    public static Image createImage(String link){
+    public static Image createImage(String link, String fileName){
         Image image = new Image();
         image.link = link;
+        image.fileName = fileName;
 
         return image;
     }

--- a/33ma3/src/main/java/softeer/be33ma3/domain/Post.java
+++ b/33ma3/src/main/java/softeer/be33ma3/domain/Post.java
@@ -58,4 +58,13 @@ public class Post extends BaseTimeEntity{
     public void setDone() {
         done = true;
     }
+
+    public void editPost(PostCreateDto postCreateDto, Region region) {
+        this.carType = postCreateDto.getCarType();
+        this.deadline = postCreateDto.getDeadline();
+        this.contents = postCreateDto.getContents();
+        this.repairService = postCreateDto.getRepairService();
+        this.tuneUpService = postCreateDto.getTuneUpService();
+        this.region = region;
+    }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/jwt/CurrentUserArgumentResolver.java
+++ b/33ma3/src/main/java/softeer/be33ma3/jwt/CurrentUserArgumentResolver.java
@@ -36,8 +36,9 @@ public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolve
 
         String accessToken = request.getHeader(ACCESS_HEADER_STRING);   //헤더에서 엑세스 토큰 가져오기
 
-        if(accessToken == null)   //토큰이 없는 경우
+        if (accessToken == null) {   //토큰이 없는 경우
             return null;
+        }
 
         Claims claims = jwtProvider.getClaims(accessToken);
         Long memberId = Long.parseLong(claims.getSubject());

--- a/33ma3/src/main/java/softeer/be33ma3/jwt/CurrentUserArgumentResolver.java
+++ b/33ma3/src/main/java/softeer/be33ma3/jwt/CurrentUserArgumentResolver.java
@@ -36,9 +36,8 @@ public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolve
 
         String accessToken = request.getHeader(ACCESS_HEADER_STRING);   //헤더에서 엑세스 토큰 가져오기
 
-        if(accessToken == null){    //토큰이 없는 경우
+        if(accessToken == null)   //토큰이 없는 경우
             return null;
-        }
 
         Claims claims = jwtProvider.getClaims(accessToken);
         Long memberId = Long.parseLong(claims.getSubject());

--- a/33ma3/src/main/java/softeer/be33ma3/jwt/intercepter/JwtAuthenticationInterceptor.java
+++ b/33ma3/src/main/java/softeer/be33ma3/jwt/intercepter/JwtAuthenticationInterceptor.java
@@ -20,26 +20,22 @@ public class JwtAuthenticationInterceptor implements HandlerInterceptor {
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
         String accessToken = getToken(request);
 
-        if(accessToken == null){    //헤더에 토큰이 없는 경우
+        if(accessToken == null)    //헤더에 토큰이 없는 경우
             throw new IllegalArgumentException("JWT 토큰 필요");
-        }
 
-        if(StringUtils.hasText(accessToken)){   //토큰이 있는 경우
+        if(StringUtils.hasText(accessToken))   //토큰이 있는 경우
             return jwtProvider.validationToken(accessToken);    //토큰 검증(마감기한, signature, jwt 형식인지)
-        }
 
         return true;
     }
 
     private String getToken(HttpServletRequest request) {
         String token = request.getHeader(ACCESS_HEADER_STRING);
-        if(!StringUtils.hasText(token)){
+        if(!StringUtils.hasText(token))
             throw new JwtTokenException("ACCESS TOKEN 필요");
-        }
 
-        if(token.startsWith(ACCESS_PREFIX_STRING)){
+        if(token.startsWith(ACCESS_PREFIX_STRING))
             return token.substring( ACCESS_PREFIX_STRING.length());
-        }
 
         return null;
     }

--- a/33ma3/src/main/java/softeer/be33ma3/jwt/intercepter/JwtAuthenticationInterceptor.java
+++ b/33ma3/src/main/java/softeer/be33ma3/jwt/intercepter/JwtAuthenticationInterceptor.java
@@ -18,8 +18,9 @@ public class JwtAuthenticationInterceptor implements HandlerInterceptor {
     private final JwtProvider jwtProvider;
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
-        if(request.getMethod().equals("OPTIONS"))
+        if(CorsUtils.isPreFlightRequest(request)) {
             return true;
+        }
 
         String accessToken = getToken(request);
 

--- a/33ma3/src/main/java/softeer/be33ma3/jwt/intercepter/JwtAuthenticationInterceptor.java
+++ b/33ma3/src/main/java/softeer/be33ma3/jwt/intercepter/JwtAuthenticationInterceptor.java
@@ -23,11 +23,13 @@ public class JwtAuthenticationInterceptor implements HandlerInterceptor {
 
         String accessToken = getToken(request);
 
-        if(accessToken == null)    //헤더에 토큰이 없는 경우
+        if (accessToken == null) {    //헤더에 토큰이 없는 경우
             throw new JwtTokenException("JWT 토큰 필요");
+        }
 
-        if(StringUtils.hasText(accessToken))   //토큰이 있는 경우
+        if (StringUtils.hasText(accessToken)) {  //토큰이 있는 경우
             return jwtProvider.validationToken(accessToken);    //토큰 검증(마감기한, signature, jwt 형식인지)
+        }
 
         return true;
     }
@@ -35,8 +37,9 @@ public class JwtAuthenticationInterceptor implements HandlerInterceptor {
     private String getToken(HttpServletRequest request) {
         String token = request.getHeader(ACCESS_HEADER_STRING);
 
-        if(StringUtils.hasText(token) && token.startsWith(ACCESS_PREFIX_STRING))
-            return token.substring( ACCESS_PREFIX_STRING.length());
+        if (StringUtils.hasText(token) && token.startsWith(ACCESS_PREFIX_STRING)) {
+            return token.substring(ACCESS_PREFIX_STRING.length());
+        }
 
         return null;
     }

--- a/33ma3/src/main/java/softeer/be33ma3/jwt/intercepter/JwtAuthenticationInterceptor.java
+++ b/33ma3/src/main/java/softeer/be33ma3/jwt/intercepter/JwtAuthenticationInterceptor.java
@@ -18,10 +18,13 @@ public class JwtAuthenticationInterceptor implements HandlerInterceptor {
     private final JwtProvider jwtProvider;
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        if(request.getMethod().equals("OPTIONS"))
+            return true;
+
         String accessToken = getToken(request);
 
         if(accessToken == null)    //헤더에 토큰이 없는 경우
-            throw new IllegalArgumentException("JWT 토큰 필요");
+            throw new JwtTokenException("JWT 토큰 필요");
 
         if(StringUtils.hasText(accessToken))   //토큰이 있는 경우
             return jwtProvider.validationToken(accessToken);    //토큰 검증(마감기한, signature, jwt 형식인지)
@@ -31,10 +34,8 @@ public class JwtAuthenticationInterceptor implements HandlerInterceptor {
 
     private String getToken(HttpServletRequest request) {
         String token = request.getHeader(ACCESS_HEADER_STRING);
-        if(!StringUtils.hasText(token))
-            throw new JwtTokenException("ACCESS TOKEN 필요");
 
-        if(token.startsWith(ACCESS_PREFIX_STRING))
+        if(StringUtils.hasText(token) && token.startsWith(ACCESS_PREFIX_STRING))
             return token.substring( ACCESS_PREFIX_STRING.length());
 
         return null;

--- a/33ma3/src/main/java/softeer/be33ma3/jwt/intercepter/RefreshTokenAuthenticationInterceptor.java
+++ b/33ma3/src/main/java/softeer/be33ma3/jwt/intercepter/RefreshTokenAuthenticationInterceptor.java
@@ -25,9 +25,8 @@ public class RefreshTokenAuthenticationInterceptor implements HandlerInterceptor
         if(jwtProvider.validationToken(refreshToken)){  //유효한 리프레시 토큰인 경우
             Claims claims = jwtProvider.getClaims(refreshToken);
 
-            if(claims.get("memberId") == null){ //토큰에 memberId가 없는 경우
+            if(claims.get("memberId") == null) //토큰에 memberId가 없는 경우
                 throw new JwtTokenException("JWT_NOT_VALID");
-            }
 
             Long memberId = Long.valueOf(claims.get("memberId").toString());
             Member member = memberRepository.findMemberByRefreshToken(refreshToken).get();

--- a/33ma3/src/main/java/softeer/be33ma3/jwt/intercepter/RefreshTokenAuthenticationInterceptor.java
+++ b/33ma3/src/main/java/softeer/be33ma3/jwt/intercepter/RefreshTokenAuthenticationInterceptor.java
@@ -25,8 +25,9 @@ public class RefreshTokenAuthenticationInterceptor implements HandlerInterceptor
         if(jwtProvider.validationToken(refreshToken)){  //유효한 리프레시 토큰인 경우
             Claims claims = jwtProvider.getClaims(refreshToken);
 
-            if(claims.get("memberId") == null) //토큰에 memberId가 없는 경우
+            if (claims.get("memberId") == null) { //토큰에 memberId가 없는 경우
                 throw new JwtTokenException("JWT_NOT_VALID");
+            }
 
             Long memberId = Long.valueOf(claims.get("memberId").toString());
             Member member = memberRepository.findMemberByRefreshToken(refreshToken).get();
@@ -39,8 +40,9 @@ public class RefreshTokenAuthenticationInterceptor implements HandlerInterceptor
 
     private String getToken(HttpServletRequest request) {
         String token = request.getHeader(REFRESH_HEADER_STRING);
-        if(!StringUtils.hasText(token))
+        if (!StringUtils.hasText(token)) {
             throw new JwtTokenException("REFRESH TOKEN 필요");
+        }
 
         return token;
     }

--- a/33ma3/src/main/java/softeer/be33ma3/repository/ImageRepository.java
+++ b/33ma3/src/main/java/softeer/be33ma3/repository/ImageRepository.java
@@ -1,6 +1,13 @@
 package softeer.be33ma3.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import softeer.be33ma3.domain.Image;
+
+import java.util.List;
+
 public interface ImageRepository extends JpaRepository<Image, Long> {
+    @Query("SELECT i.fileName FROM Image i WHERE i.imageId IN :imageIds")
+    List<String> findFileNamesByImageIds(@Param("imageIds") List<Long> imageIds);
 }

--- a/33ma3/src/main/java/softeer/be33ma3/service/ImageService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/ImageService.java
@@ -25,10 +25,23 @@ public class ImageService {
 
         for (MultipartFile file : multipartFiles) {
             String fileName = s3Service.uploadFile(file);
-            images.add(Image.createImage(s3Service.getFileUrl(fileName)));
+            images.add(Image.createImage(s3Service.getFileUrl(fileName), fileName));
         }
 
         List<Image> savedImages = imageRepository.saveAll(images);
         return ImageListDto.create(savedImages);
+    }
+
+    @Transactional
+    public void deleteImage(List<Image> images){
+        List<Long> imageIds = images.stream()
+                .map(Image::getImageId)
+                .toList();
+
+        List<String> fileNames = imageRepository.findFileNamesByImageIds(imageIds);
+
+        for (String fileName : fileNames) {
+            s3Service.deleteFile(fileName);
+        }
     }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/service/ImageService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/ImageService.java
@@ -19,8 +19,6 @@ public class ImageService {
     private final ImageRepository imageRepository;
     @Transactional
     public ImageListDto saveImage(List<MultipartFile> multipartFiles){
-        //TODO: 로그인 구현하고 존재하는 회원인지 확인하는 로직 추가하기
-
         List<Image> images = new ArrayList<>();
 
         for (MultipartFile file : multipartFiles) {

--- a/33ma3/src/main/java/softeer/be33ma3/service/MemberService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/MemberService.java
@@ -39,8 +39,6 @@ public class MemberService {
         if(memberRepository.findMemberByLoginId(centerSignUpDto.getLoginId()).isPresent())
             throw new IllegalArgumentException("이미 존재하는 아이디");
 
-        //TODO: 센터이름도 중복인지 확인하기
-
         Member member = Member.createMember(CENTER_TYPE, centerSignUpDto.getLoginId(), centerSignUpDto.getPassword());
         member = memberRepository.save(member);
 

--- a/33ma3/src/main/java/softeer/be33ma3/service/MemberService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/MemberService.java
@@ -27,8 +27,9 @@ public class MemberService {
 
     @Transactional
     public void clientSignUp(ClientSignUpDto clientSignUpDto) {
-        if(memberRepository.findMemberByLoginId(clientSignUpDto.getLoginId()).isPresent())  //아이디가 이미 존재하는 경우
+        if (memberRepository.findMemberByLoginId(clientSignUpDto.getLoginId()).isPresent()) {//아이디가 이미 존재하는 경우
             throw new IllegalArgumentException("이미 존재하는 아이디");
+        }
 
         Member member = Member.createMember(CLIENT_TYPE, clientSignUpDto.getLoginId(), clientSignUpDto.getPassword());
         memberRepository.save(member);
@@ -36,8 +37,9 @@ public class MemberService {
 
     @Transactional
     public void centerSignUp(CenterSignUpDto centerSignUpDto) {
-        if(memberRepository.findMemberByLoginId(centerSignUpDto.getLoginId()).isPresent())
+        if (memberRepository.findMemberByLoginId(centerSignUpDto.getLoginId()).isPresent()) {
             throw new IllegalArgumentException("이미 존재하는 아이디");
+        }
 
         Member member = Member.createMember(CENTER_TYPE, centerSignUpDto.getLoginId(), centerSignUpDto.getPassword());
         member = memberRepository.save(member);

--- a/33ma3/src/main/java/softeer/be33ma3/service/MemberService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/MemberService.java
@@ -27,9 +27,8 @@ public class MemberService {
 
     @Transactional
     public void clientSignUp(ClientSignUpDto clientSignUpDto) {
-        if(memberRepository.findMemberByLoginId(clientSignUpDto.getLoginId()).isPresent()){//아이디가 이미 존재하는 경우
+        if(memberRepository.findMemberByLoginId(clientSignUpDto.getLoginId()).isPresent())  //아이디가 이미 존재하는 경우
             throw new IllegalArgumentException("이미 존재하는 아이디");
-        }
 
         Member member = Member.createMember(CLIENT_TYPE, clientSignUpDto.getLoginId(), clientSignUpDto.getPassword());
         memberRepository.save(member);
@@ -37,9 +36,8 @@ public class MemberService {
 
     @Transactional
     public void centerSignUp(CenterSignUpDto centerSignUpDto) {
-        if(memberRepository.findMemberByLoginId(centerSignUpDto.getLoginId()).isPresent()){
+        if(memberRepository.findMemberByLoginId(centerSignUpDto.getLoginId()).isPresent())
             throw new IllegalArgumentException("이미 존재하는 아이디");
-        }
 
         //TODO: 센터이름도 중복인지 확인하기
 

--- a/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
@@ -112,9 +112,8 @@ public class PostService {
         Pattern pattern = Pattern.compile("\\b([^\\s]+구)\\b");
         Matcher matcher = pattern.matcher(location);
 
-        if (matcher.find()) {
+        if (matcher.find())
             return regionRepository.findByRegionName(matcher.group()).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 구"));
-        }
 
         throw new IllegalArgumentException("주소에서 구를 찾을 수 없음");
     }
@@ -133,13 +132,12 @@ public class PostService {
         Post post = postRepository.findById(postId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글"));
         Member findMember = memberRepository.findById(member.getMemberId()).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원"));
 
-        if(!post.getMember().equals(findMember)){
+        if(!post.getMember().equals(findMember))
             throw new UnauthorizedException("작성자만 가능합니다.");
-        }
 
-        if(!offerRepository.findByPost_PostId(postId).isEmpty()){  //댓글이 있는 경우(경매 시작 후)
+        if(!offerRepository.findByPost_PostId(postId).isEmpty())  //댓글이 있는 경우(경매 시작 후)
             throw new IllegalArgumentException("경매 시작 전에만 가능합니다.");
-        }
+
         return post;
     }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
@@ -6,7 +6,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import softeer.be33ma3.domain.*;
-import softeer.be33ma3.dto.request.LoginDto;
 import softeer.be33ma3.dto.request.PostCreateDto;
 import softeer.be33ma3.dto.response.ImageListDto;
 import softeer.be33ma3.dto.response.OfferDetailDto;
@@ -115,8 +114,9 @@ public class PostService {
         Pattern pattern = Pattern.compile("\\b([^\\s]+구)\\b");
         Matcher matcher = pattern.matcher(location);
 
-        if (matcher.find())
+        if (matcher.find()) {
             return regionRepository.findByRegionName(matcher.group()).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 구"));
+        }
 
         throw new IllegalArgumentException("주소에서 구를 찾을 수 없음");
     }
@@ -135,11 +135,13 @@ public class PostService {
         Post post = postRepository.findById(postId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글"));
         Member findMember = memberRepository.findById(member.getMemberId()).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원"));
 
-        if(!post.getMember().equals(findMember))
+        if (!post.getMember().equals(findMember)) {
             throw new UnauthorizedException("작성자만 가능합니다.");
+        }
 
-        if(!offerRepository.findByPost_PostId(postId).isEmpty())  //댓글이 있는 경우(경매 시작 후)
+        if (!offerRepository.findByPost_PostId(postId).isEmpty()) { //댓글이 있는 경우(경매 시작 후)
             throw new IllegalArgumentException("경매 시작 전에만 가능합니다.");
+        }
 
         return post;
     }

--- a/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
@@ -23,6 +23,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class PostService {
+    private static final int CLIENT_TYPE = 1;
 
     private final OfferRepository offerRepository;
     private final CenterRepository centerRepository;
@@ -37,6 +38,9 @@ public class PostService {
     public Long createPost(Member currentMember, PostCreateDto postCreateDto, List<MultipartFile> multipartFiles) {
         //회원이랑 지역 찾기
         Member member = memberRepository.findById(currentMember.getMemberId()).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원"));
+        if(member.getMemberType() != CLIENT_TYPE){
+            throw new UnauthorizedException("센터는 글 작성이 불가능합니다.");
+        }
         Region region = getRegion(postCreateDto.getLocation());
 
         //이미지 저장

--- a/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import softeer.be33ma3.domain.*;
+import softeer.be33ma3.dto.request.LoginDto;
 import softeer.be33ma3.dto.request.PostCreateDto;
 import softeer.be33ma3.dto.response.ImageListDto;
 import softeer.be33ma3.dto.response.OfferDetailDto;
@@ -34,7 +35,7 @@ public class PostService {
     private final ImageService imageService;
 
     @Transactional
-    public void createPost(Member currentMember, PostCreateDto postCreateDto, List<MultipartFile> multipartFiles) {
+    public Long createPost(Member currentMember, PostCreateDto postCreateDto, List<MultipartFile> multipartFiles) {
         //회원이랑 지역 찾기
         Member member = memberRepository.findById(currentMember.getMemberId()).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원"));
         Region region = getRegion(postCreateDto.getLocation());
@@ -52,6 +53,8 @@ public class PostService {
         //이미지랑 게시물 매핑하기
         List<Image> images = imageRepository.findAllById(imageListDto.getImageIds());
         images.forEach(image -> image.setPost(savedPost));
+
+        return savedPost.getPostId();
     }
 
 

--- a/33ma3/src/main/java/softeer/be33ma3/service/S3Service.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/S3Service.java
@@ -34,8 +34,7 @@ public class S3Service {
 
         //파일 업로드
         try (InputStream inputStream = file.getInputStream()) {
-            amazonS3Client.putObject(
-                    new PutObjectRequest(bucket, fileName, inputStream, objectMetadata)
+            amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, inputStream, objectMetadata)
                             .withCannedAcl(CannedAccessControlList.PublicReadWrite));
         } catch (IOException e) {
             throw new IllegalArgumentException("파일을 변환할 수 없음");

--- a/33ma3/src/main/java/softeer/be33ma3/service/S3Service.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/S3Service.java
@@ -2,6 +2,7 @@ package softeer.be33ma3.service;
 
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import lombok.RequiredArgsConstructor;
@@ -46,6 +47,11 @@ public class S3Service {
     //이미지 link 가져오기
     public String getFileUrl(String fileName) {
         return amazonS3Client.getUrl(bucket, fileName).toString();
+    }
+
+    //S3에 올라간 이미지 삭제 기능
+    public void deleteFile(String fileName) {
+        amazonS3Client.deleteObject(new DeleteObjectRequest(bucket, fileName));
     }
 
     //파일 이름 생성 : 이름이 같으면 같은 이름인 이미지를 덮어씌우는 문제가 생기기 때문에 이미지 이름을 생성해서 저장하도록 구현

--- a/33ma3/src/test/java/softeer/be33ma3/repository/ImageRepositoryTest.java
+++ b/33ma3/src/test/java/softeer/be33ma3/repository/ImageRepositoryTest.java
@@ -1,0 +1,47 @@
+package softeer.be33ma3.repository;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import softeer.be33ma3.domain.Image;
+
+import java.util.List;
+
+
+@SpringBootTest
+@ActiveProfiles("test")
+class ImageRepositoryTest {
+    @Autowired private ImageRepository imageRepository;
+
+    @AfterEach
+    void tearDown(){
+        imageRepository.deleteAllInBatch();
+    }
+
+
+    @DisplayName("이미지 아이디 리스트로 파일 이름을 찾을 수 있다.")
+    @Test
+    void findFileNamesByImageIdIn(){
+        //given
+        Image image1 = Image.createImage("aaaaaa", "test1");
+        Image image2 = Image.createImage("bbbbbb", "test2");
+        Image image3 = Image.createImage("cccccc", "test3");
+
+        List<Image> images = imageRepository.saveAll(List.of(image1, image2, image3));
+
+        List<Long> imageIds = images.stream()
+                .map(Image::getImageId)
+                .toList();
+
+        //when
+        List<String> fileNames = imageRepository.findFileNamesByImageIds(imageIds);
+
+        //then
+        Assertions.assertThat(fileNames).hasSize(3)
+                .contains("test1", "test2", "test3");
+    }
+}

--- a/33ma3/src/test/java/softeer/be33ma3/service/PostServiceTest.java
+++ b/33ma3/src/test/java/softeer/be33ma3/service/PostServiceTest.java
@@ -43,6 +43,7 @@ class PostServiceTest {
     void tearDown(){
         postRepository.deleteAllInBatch();
         memberRepository.deleteAllInBatch();
+        regionRepository.deleteAllInBatch();
     }
 
     @DisplayName("게시글을 수정할 수 있다.")

--- a/33ma3/src/test/java/softeer/be33ma3/service/PostServiceTest.java
+++ b/33ma3/src/test/java/softeer/be33ma3/service/PostServiceTest.java
@@ -1,0 +1,92 @@
+package softeer.be33ma3.service;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import softeer.be33ma3.domain.Member;
+import softeer.be33ma3.domain.Post;
+import softeer.be33ma3.domain.Region;
+import softeer.be33ma3.dto.request.PostCreateDto;
+import softeer.be33ma3.exception.UnauthorizedException;
+import softeer.be33ma3.repository.MemberRepository;
+import softeer.be33ma3.repository.PostRepository;
+import softeer.be33ma3.repository.RegionRepository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class PostServiceTest {
+    @Autowired private PostService postService;
+    @Autowired private PostRepository postRepository;
+    @Autowired private MemberRepository memberRepository;
+    @Autowired private RegionRepository regionRepository;
+
+    @BeforeEach
+    void setUp(){
+        //회원 저장
+        Member member1 = Member.createMember(1, "client1", "1234");
+        Member member2 = Member.createMember(1, "client2", "1234");
+        memberRepository.saveAll(List.of(member1, member2));
+        regionRepository.save(new Region(1L, "강남구"));
+    }
+
+    @AfterEach
+    void tearDown(){
+        postRepository.deleteAllInBatch();
+        memberRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("게시글을 수정할 수 있다.")
+    @Test
+    void editPost(){
+        //given
+        Member member = memberRepository.findMemberByLoginId("client1").get();
+        Region region = regionRepository.findByRegionName("강남구").get();
+
+        Post savedPost = savePost(region, member);
+
+        PostCreateDto postEditDto = new PostCreateDto("승용차", "제네시스", 3, "서울시 강남구", "기스, 깨짐", "오일 교체", new ArrayList<>(),"수정후 내용");
+
+        //when
+        postService.editPost(member, savedPost.getPostId(), postEditDto);
+
+        //then
+        Post editPost = postRepository.findById(savedPost.getPostId()).get();
+        assertThat(editPost.getContents()).isEqualTo("수정후 내용");
+    }
+
+    @DisplayName("작성자와 다른 사람이 수정하면 예외가 발생한다.")
+    @Test
+    void editPostWithOtherMember(){
+        //given
+        Member member1 = memberRepository.findMemberByLoginId("client1").get();
+        Member member2 = memberRepository.findMemberByLoginId("client2").get();
+        Region region = regionRepository.findByRegionName("강남구").get();
+
+        Post savedPost = savePost(region, member1);
+
+        PostCreateDto postEditDto = new PostCreateDto("승용차", "제네시스", 3, "서울시 강남구", "기스, 깨짐", "오일 교체", new ArrayList<>(),"수정후 내용");
+
+        //when //then
+        assertThatThrownBy(() -> postService.editPost(member2, savedPost.getPostId(), postEditDto))
+                .isInstanceOf(UnauthorizedException.class)
+                .hasMessage("작성자만 가능합니다.");
+    }
+
+    private Post savePost(Region region, Member member1) {
+        PostCreateDto postCreateDto = new PostCreateDto("승용차", "제네시스", 3, "서울시 강남구", "기스, 깨짐", "오일 교체", new ArrayList<>(),"수정전 내용");
+        Post post = Post.createPost(postCreateDto, region, member1);
+        Post savedPost = postRepository.save(post);
+
+        return savedPost;
+    }
+}


### PR DESCRIPTION
## 구현 내용
- [x] 게시물 수정 기능 구현
- [x] 게시물 삭제 기능 구현
- 수정, 삭제 둘 다 작성자만 가능하고, 경매가 시작전인 경우에만 가능하도록 구현
- [x] 이미지 삭제 기능 구현
- [x] 테스트 코드 작성

## 고민 사항
- 이미지를 삭제할때 id list로 해당하는 fileName을 전부 가져오는 메소드를 쿼리를 작성하지 않고 구현하고 싶었는데, 잘 안돼서 쿼리를 작성했다. 메소드 이름을 잘 지으면 할 수 있을 것 같은데.. 우선은 쿼리로 했다. 
- Jwt와 Interceptor 사용 시 CORS 에러가 발생하는 이유
Jwt를 추가하기 전에 게시글 작성 시 CORS 문제를 해결해서 정상적으로 작동하는 것을 확인했으나, Jwt를 추가 하고나서 프론트에서는 CORS에러가 백에서는 헤더에 토큰이 없다는 에러가 발생했다! 프론트에서 헤더에 토큰을 정상적으로 담아서 보내줬는데 오류가 왜 날까 고민을 하다가 하나는 preflight 요청이 있다는 것을 알았다! preflight 요청 시에는 헤더를 포함하지 않기 때문에, 인터셉터에서 request.getHeader를 할 때 Authorization 헤더를 찾을 수 없었던 것이다. 그래서 preflight의 request method인 OPTIONS의 요청이 오면 인터셉터를 통과하도록 하여 오류를 해결할 수 있었다! 근데 추후에 찾아보니 해당 요청을 판별할 수 있는 메서드가 있어서 그 메소드를 사용하는 방식으로 수정했다!

## 기타
보경아 알면 가르쳐줘~