### PR TITLE
웹소켓 통신 방법 수정 #87

### DIFF
--- a/33ma3/src/main/java/softeer/be33ma3/config/WebSocketConfig.java
+++ b/33ma3/src/main/java/softeer/be33ma3/config/WebSocketConfig.java
@@ -15,6 +15,6 @@ public class WebSocketConfig implements WebSocketConfigurer {
     private final WebSocketHandler webSocketHandler;
     @Override
     public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
-        registry.addHandler(webSocketHandler, "/connect").setAllowedOrigins("*");
+        registry.addHandler(webSocketHandler, "/connect/{postId}/{memberId}").setAllowedOrigins("*");
     }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/controller/OfferController.java
+++ b/33ma3/src/main/java/softeer/be33ma3/controller/OfferController.java
@@ -77,7 +77,7 @@ public class OfferController {
     @PatchMapping("/{post_id}/offer/{offer_id}")
     public ResponseEntity<?> updateOffer(@PathVariable("post_id") Long postId,
                                          @PathVariable("offer_id") Long offerId,
-                                         @RequestBody OfferCreateDto offerCreateDto,
+                                         @RequestBody @Valid OfferCreateDto offerCreateDto,
                                          @Schema(hidden = true) @CurrentUser Member member) {
         offerService.updateOffer(postId, offerId, offerCreateDto, member);
         // 글 작성자에게 업데이트 된 댓글 리스트 보내기

--- a/33ma3/src/main/java/softeer/be33ma3/controller/PostController.java
+++ b/33ma3/src/main/java/softeer/be33ma3/controller/PostController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import softeer.be33ma3.domain.Member;
 import softeer.be33ma3.dto.request.PostCreateDto;
+import softeer.be33ma3.dto.response.PostWithOffersDto;
 import softeer.be33ma3.jwt.CurrentUser;
 import softeer.be33ma3.response.DataResponse;
 import softeer.be33ma3.response.SingleResponse;
@@ -54,7 +55,7 @@ public class PostController {
     @GetMapping("/one/{post_id}")
     public ResponseEntity<?> showPost(@PathVariable("post_id") Long postId,
                                       @Schema(hidden = true) @CurrentUser Member member) {
-        List<Object> getPostResult = postService.showPost(postId, member);
-        return ResponseEntity.ok(DataResponse.success("게시글 조회 완료", getPostResult));
+        Object result = postService.showPost(postId, member);
+        return ResponseEntity.ok(DataResponse.success("게시글 조회 완료", result));
     }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/controller/PostController.java
+++ b/33ma3/src/main/java/softeer/be33ma3/controller/PostController.java
@@ -15,7 +15,6 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import softeer.be33ma3.domain.Member;
 import softeer.be33ma3.dto.request.PostCreateDto;
-import softeer.be33ma3.dto.response.PostWithOffersDto;
 import softeer.be33ma3.jwt.CurrentUser;
 import softeer.be33ma3.response.DataResponse;
 import softeer.be33ma3.response.SingleResponse;

--- a/33ma3/src/main/java/softeer/be33ma3/dto/response/AvgPriceDto.java
+++ b/33ma3/src/main/java/softeer/be33ma3/dto/response/AvgPriceDto.java
@@ -1,0 +1,9 @@
+package softeer.be33ma3.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+@Data
+@AllArgsConstructor
+public class AvgPriceDto {
+    private double avgPrice;
+}

--- a/33ma3/src/main/java/softeer/be33ma3/dto/response/OfferDetailDto.java
+++ b/33ma3/src/main/java/softeer/be33ma3/dto/response/OfferDetailDto.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.List;
 
 @Getter
+@Builder
 @Schema(description = "견적 상세보기 응답 DTO")
 public class OfferDetailDto implements Comparable<OfferDetailDto> {
     @Schema(description = "견적 아이디", example = "1")
@@ -26,15 +27,6 @@ public class OfferDetailDto implements Comparable<OfferDetailDto> {
 
     @Schema(description = "낙찰 여부", example = "false")
     private boolean selected;
-
-    @Builder
-    private OfferDetailDto(Long offerId, String centerName, int price, String contents, boolean selected) {
-        this.offerId = offerId;
-        this.centerName = centerName;
-        this.price = price;
-        this.contents = contents;
-        this.selected = selected;
-    }
 
     // Offer Entity -> OfferDetailDto 변환
     public static OfferDetailDto fromEntity(Offer offer) {

--- a/33ma3/src/main/java/softeer/be33ma3/dto/response/OfferDetailDto.java
+++ b/33ma3/src/main/java/softeer/be33ma3/dto/response/OfferDetailDto.java
@@ -19,7 +19,7 @@ public class OfferDetailDto implements Comparable<OfferDetailDto> {
     @Schema(description = "센터 이름", example = "현대자동차 강남점")
     private String centerName;
 
-    @Schema(description = "멤버 아이디", example = "1")
+    @Schema(description = "견적 제시 가격", example = "1")
     private int price;
 
     @Schema(description = "견적 내용", example = "사진상으로는 10만원에 가능할듯 합니다.")

--- a/33ma3/src/main/java/softeer/be33ma3/dto/response/PostDetailDto.java
+++ b/33ma3/src/main/java/softeer/be33ma3/dto/response/PostDetailDto.java
@@ -52,7 +52,7 @@ public class PostDetailDto {
         List<String> repairList = stringCommaParsing(post.getRepairService());
         List<String> tuneUpList = stringCommaParsing(post.getTuneUpService());
         List<String> imageList = post.getImages().stream().map(Image::getLink).toList();
-        Duration duration = Duration.between(LocalDateTime.now(), post.getCreateTime().plusDays(post.getDeadline()));
+        Duration duration = calculateDuration(post);
         int dDay = -1;
         LocalTime remainTime = null;
         if(!post.isDone() && !duration.isNegative())        // 아직 마감 시간 전
@@ -80,6 +80,12 @@ public class PostDetailDto {
         return Arrays.stream(inputString.split(","))
                 .map(String::strip)
                 .toList();
+    }
+
+    private static Duration calculateDuration(Post post) {
+        LocalDateTime endTime = post.getCreateTime().plusDays(post.getDeadline());
+        endTime = endTime.withHour(23).withMinute(59).withSecond(59);
+        return Duration.between(LocalDateTime.now(), endTime);
     }
 
     // 마감 시간까지 남은 시간:분:초를 반환

--- a/33ma3/src/main/java/softeer/be33ma3/dto/response/PostDetailDto.java
+++ b/33ma3/src/main/java/softeer/be33ma3/dto/response/PostDetailDto.java
@@ -75,6 +75,8 @@ public class PostDetailDto {
 
     // 구분자 콤마로 문자열 파싱 후 각각의 토큰에서 공백 제거 후 리스트 반환
     private static List<String> stringCommaParsing(String inputString) {
+        if(inputString.isEmpty())
+            return List.of();
         return Arrays.stream(inputString.split(","))
                 .map(String::strip)
                 .toList();

--- a/33ma3/src/main/java/softeer/be33ma3/dto/response/PostWithAvgPriceDto.java
+++ b/33ma3/src/main/java/softeer/be33ma3/dto/response/PostWithAvgPriceDto.java
@@ -8,18 +8,18 @@ import lombok.Getter;
 @Schema(description = "게시글과 평균가 DTO")
 public class PostWithAvgPriceDto {
     @Schema(description = "게시글 세부사항")
-    private PostDetailDto postDetailDto;
+    private PostDetailDto postDetail;
     @Schema(description = "평균 제시 가격", example = "10.5")
     private double avgPrice;
     @Schema(description = "작성한 댓글 세부사항")
-    private OfferDetailDto offerDetailDto;      // 견적을 작성한 이력이 있는 서비스 센터의 경우 작성한 댓글 정보 보내주기
+    private OfferDetailDto offerDetail;      // 견적을 작성한 이력이 있는 서비스 센터의 경우 작성한 댓글 정보 보내주기
 
     public PostWithAvgPriceDto(PostDetailDto postDetailDto, double avgPrice) {
-        this.postDetailDto = postDetailDto;
+        this.postDetail = postDetailDto;
         this.avgPrice = avgPrice;
     }
 
     public void setOfferDetailDto(OfferDetailDto offerDetailDto) {
-        this.offerDetailDto = offerDetailDto;
+        this.offerDetail = offerDetailDto;
     }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/dto/response/PostWithAvgPriceDto.java
+++ b/33ma3/src/main/java/softeer/be33ma3/dto/response/PostWithAvgPriceDto.java
@@ -1,0 +1,25 @@
+package softeer.be33ma3.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@Schema(description = "게시글과 평균가 DTO")
+public class PostWithAvgPriceDto {
+    @Schema(description = "게시글 세부사항")
+    private PostDetailDto postDetailDto;
+    @Schema(description = "평균 제시 가격", example = "10.5")
+    private double avgPrice;
+    @Schema(description = "작성한 댓글 세부사항")
+    private OfferDetailDto offerDetailDto;      // 견적을 작성한 이력이 있는 서비스 센터의 경우 작성한 댓글 정보 보내주기
+
+    public PostWithAvgPriceDto(PostDetailDto postDetailDto, double avgPrice) {
+        this.postDetailDto = postDetailDto;
+        this.avgPrice = avgPrice;
+    }
+
+    public void setOfferDetailDto(OfferDetailDto offerDetailDto) {
+        this.offerDetailDto = offerDetailDto;
+    }
+}

--- a/33ma3/src/main/java/softeer/be33ma3/dto/response/PostWithOffersDto.java
+++ b/33ma3/src/main/java/softeer/be33ma3/dto/response/PostWithOffersDto.java
@@ -1,0 +1,17 @@
+package softeer.be33ma3.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "게시글과 댓글 목록 DTO")
+public class PostWithOffersDto {
+    @Schema(description = "게시글 세부사항")
+    private PostDetailDto postDetailDto;
+    @Schema(description = "게시글에 달린 댓글 리스트")
+    private List<OfferDetailDto> offerDetailDtos;
+}

--- a/33ma3/src/main/java/softeer/be33ma3/dto/response/PostWithOffersDto.java
+++ b/33ma3/src/main/java/softeer/be33ma3/dto/response/PostWithOffersDto.java
@@ -11,7 +11,7 @@ import java.util.List;
 @Schema(description = "게시글과 댓글 목록 DTO")
 public class PostWithOffersDto {
     @Schema(description = "게시글 세부사항")
-    private PostDetailDto postDetailDto;
+    private PostDetailDto postDetail;
     @Schema(description = "게시글에 달린 댓글 리스트")
-    private List<OfferDetailDto> offerDetailDtos;
+    private List<OfferDetailDto> offerDetails;
 }

--- a/33ma3/src/main/java/softeer/be33ma3/repository/WebSocketRepository.java
+++ b/33ma3/src/main/java/softeer/be33ma3/repository/WebSocketRepository.java
@@ -5,24 +5,46 @@ import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Repository;
 import org.springframework.web.socket.WebSocketSession;
 
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Repository
 @Slf4j
 public class WebSocketRepository {
+
+    // postId : set of memberId
+    private final Map<Long, Set<Long>> postRoom = new ConcurrentHashMap<>();
+    // memberId : WebSocketSession
     private final Map<Long, WebSocketSession> sessions = new ConcurrentHashMap<>();
+
+    public void save(Long postId, Long memberId) {
+        Set<Long> members;
+        if(postRoom.containsKey(postId))
+            members = postRoom.get(postId);
+        else
+            members = new HashSet<>();
+        members.add(memberId);
+        postRoom.put(postId, members);
+        log.info("{}번 게시글에 {}번 유저 입장", postId, memberId);
+    }
 
     public void save(Long memberId, WebSocketSession webSocketSession) {
         sessions.put(memberId, webSocketSession);
-        log.info("WebSocketSession db : {}", sessions.size());
+        log.info("{}번 유저 웹소켓 세션 저장 성공", memberId);
     }
 
-    public WebSocketSession findById(Long memberId) {
-        return sessions.get(memberId);
-    }
-
-    public void delete(Long memberId) {
-        sessions.remove(memberId);
-    }
+//    public void save(Long memberId, WebSocketSession webSocketSession) {
+//        sessions.put(memberId, webSocketSession);
+//        log.info("WebSocketSession db : {}", sessions.size());
+//    }
+//
+//    public WebSocketSession findById(Long memberId) {
+//        return sessions.get(memberId);
+//    }
+//
+//    public void delete(Long memberId) {
+//        sessions.remove(memberId);
+//    }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
@@ -104,10 +104,10 @@ public class OfferService {
         // 5. 댓글 낙찰, 게시글 마감 처리
         offer.setSelected();
         post.setDone();
-        // 6-1. 서비스 센터들에게 낙찰 또는 경매 마감 메세지 보내기
-        // 6-2. 해당 게시글에 연관되어 있는 모든 유저에 대해 웹 소켓 연결 close (게시글 작성자 + 댓글 작성자들)
+        // 6. 서비스 센터들에게 낙찰 또는 경매 마감 메세지 보내기
         Long selectedMemberId = offer.getCenter().getMember().getMemberId();
-        sendMessageAfterSelection(postId, member.getMemberId(), selectedMemberId);
+        sendMessageAfterSelection(postId, selectedMemberId);
+        webSocketHandler.deletePostRoom(postId);
     }
 
     // 해당 게시글을 가져오고, 마감 전인지 판단
@@ -162,8 +162,7 @@ public class OfferService {
     }
   
     // 낙찰 처리 후 서비스 센터들에게 낙찰 메세지, 경매 마감 메세지 전송
-    // 해당 게시글에 연관된 모든 유저들과 웹 소켓 연결 종료
-    private void sendMessageAfterSelection(Long postId, Long clientId, Long selectedMemberId) {
+    private void sendMessageAfterSelection(Long postId, Long selectedMemberId) {
         // 낙찰 메세지
         DataResponse<Long> selectAlert = DataResponse.success("제시한 견적이 낙찰되었습니다.", postId);
         webSocketHandler.sendData2Client(selectedMemberId, selectAlert);

--- a/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
@@ -3,7 +3,7 @@ package softeer.be33ma3.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import softeer.be33ma3.controller.WebSocketHandler;
+import softeer.be33ma3.websocket.WebSocketHandler;
 import softeer.be33ma3.domain.Center;
 import softeer.be33ma3.domain.Member;
 import softeer.be33ma3.domain.Offer;
@@ -86,9 +86,8 @@ public class OfferService {
         // 4. 댓글 작성자인지 검증
         if(!offer.getCenter().equals(center))
             throw new UnauthorizedException("작성자만 삭제 가능합니다.");
-        // 5. 댓글 삭제, 해당 센터와의 실시간 연결 끊기
+        // 5. 댓글 삭제
         offerRepository.delete(offer);
-        webSocketHandler.closeConnection(member.getMemberId());
     }
 
     // 견적 제시 댓글 낙찰
@@ -174,8 +173,8 @@ public class OfferService {
         memberIdsInPost.stream()
                 .filter(memberId -> !memberId.equals(selectedMemberId))
                 .forEach(memberId -> webSocketHandler.sendData2Client(memberId, endAlert));
-        // 웹 소켓 연결 종료
-        memberIdsInPost.add(clientId);
-        memberIdsInPost.forEach(webSocketHandler::closeConnection);
+        // TODO: 웹 소켓 연결 종료
+        // memberIdsInPost.add(clientId);
+        // memberIdsInPost.forEach(webSocketHandler::closeConnection);
     }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
@@ -3,6 +3,7 @@ package softeer.be33ma3.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import softeer.be33ma3.dto.response.AvgPriceDto;
 import softeer.be33ma3.websocket.WebSocketHandler;
 import softeer.be33ma3.domain.Center;
 import softeer.be33ma3.domain.Member;
@@ -155,9 +156,9 @@ public class OfferService {
         // 2. 견적 작성자의 member id 가져오기
         List<Long> memberList = findMemberIdsWithOfferList(offerList);
         // 3. 평균 견적 가격 계산하기
-        double avgPrice = calculateAvgPrice(offerList);
+        AvgPriceDto avgPriceDto = new AvgPriceDto(calculateAvgPrice(offerList));
         // 4. 전송하기
-        memberList.forEach(memberId -> webSocketHandler.sendData2Client(memberId, avgPrice));
+        memberList.forEach(memberId -> webSocketHandler.sendData2Client(memberId, avgPriceDto));
     }
   
     // 낙찰 처리 후 서비스 센터들에게 낙찰 메세지, 경매 마감 메세지 전송
@@ -173,8 +174,5 @@ public class OfferService {
         memberIdsInPost.stream()
                 .filter(memberId -> !memberId.equals(selectedMemberId))
                 .forEach(memberId -> webSocketHandler.sendData2Client(memberId, endAlert));
-        // TODO: 웹 소켓 연결 종료
-        // memberIdsInPost.add(clientId);
-        // memberIdsInPost.forEach(webSocketHandler::closeConnection);
     }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
@@ -92,6 +92,7 @@ public class PostService {
         // 해당 게시글의 견적 모두 가져오기
         List<Offer> offerList = offerRepository.findByPost_PostId(postId);
         double avgPrice = OfferService.calculateAvgPrice(offerList);
+        avgPrice = Math.round(avgPrice * 10) / 10.0;      // 소수점 첫째 자리까지 반올림
         PostWithAvgPriceDto postWithAvgPriceDto = new PostWithAvgPriceDto(postDetailDto, avgPrice);
         // 견적을 작성한 이력이 있는 서비스 센터의 접근일 경우 작성한 견적 가져오기
         OfferDetailDto offerDetailDto = getCenterOffer(postId, member);

--- a/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
@@ -7,9 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import softeer.be33ma3.domain.*;
 import softeer.be33ma3.dto.request.PostCreateDto;
-import softeer.be33ma3.dto.response.ImageListDto;
-import softeer.be33ma3.dto.response.OfferDetailDto;
-import softeer.be33ma3.dto.response.PostDetailDto;
+import softeer.be33ma3.dto.response.*;
 import softeer.be33ma3.exception.UnauthorizedException;
 import softeer.be33ma3.repository.*;
 
@@ -79,7 +77,7 @@ public class PostService {
     }
 
     // 게시글 세부사항 반환 (로그인 하지 않아도 확인 가능)
-    public List<Object> showPost(Long postId, Member member) {
+    public Object showPost(Long postId, Member member) {
         // 1. 게시글 존재 유무 판단
         Post post = postRepository.findById(postId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글"));
         // 2. 게시글 세부 사항 가져오기
@@ -87,16 +85,18 @@ public class PostService {
         // 3. 경매가 완료되었거나 글 작성자의 접근일 경우
         if(post.isDone() || (member!=null && post.getMember().equals(member))) {
             List<Offer> offerList = offerRepository.findByPost_PostId(postId);
-            List<OfferDetailDto> offerDetailList = OfferDetailDto.fromEntityList(offerList);
-            return List.of(postDetailDto, offerDetailList);
+            List<OfferDetailDto> offerDetailDtos = OfferDetailDto.fromEntityList(offerList);
+            return new PostWithOffersDto(postDetailDto, offerDetailDtos);
         }
         // 4. 경매가 진행 중이고 작성자가 아닌 유저의 접근일 경우
         // 해당 게시글의 견적 모두 가져오기
         List<Offer> offerList = offerRepository.findByPost_PostId(postId);
         double avgPrice = OfferService.calculateAvgPrice(offerList);
+        PostWithAvgPriceDto postWithAvgPriceDto = new PostWithAvgPriceDto(postDetailDto, avgPrice);
         // 견적을 작성한 이력이 있는 서비스 센터의 접근일 경우 작성한 견적 가져오기
         OfferDetailDto offerDetailDto = getCenterOffer(postId, member);
-        return (offerDetailDto == null) ? List.of(postDetailDto, avgPrice) : List.of(postDetailDto, avgPrice, offerDetailDto);
+        postWithAvgPriceDto.setOfferDetailDto(offerDetailDto);
+        return postWithAvgPriceDto;
     }
 
     // 멤버 정보를 이용하여 견적을 작성한 이력이 있는 서비스 센터일 경우 작성한 견적 반환

--- a/33ma3/src/main/java/softeer/be33ma3/websocket/ExitMember.java
+++ b/33ma3/src/main/java/softeer/be33ma3/websocket/ExitMember.java
@@ -5,7 +5,7 @@ import lombok.NoArgsConstructor;
 
 @Data
 @NoArgsConstructor
-public class ExitUser {
+public class ExitMember {
     private String type;
     private Long roomId;
     private Long memberId;

--- a/33ma3/src/main/java/softeer/be33ma3/websocket/ExitUser.java
+++ b/33ma3/src/main/java/softeer/be33ma3/websocket/ExitUser.java
@@ -1,0 +1,12 @@
+package softeer.be33ma3.websocket;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class ExitUser {
+    private String type;
+    private Long roomId;
+    private Long memberId;
+}

--- a/33ma3/src/main/java/softeer/be33ma3/websocket/HandShakeInterceptor.java
+++ b/33ma3/src/main/java/softeer/be33ma3/websocket/HandShakeInterceptor.java
@@ -1,0 +1,45 @@
+package softeer.be33ma3.websocket;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+import java.util.Map;
+
+@Component
+@Slf4j
+public class HandShakeInterceptor implements HandshakeInterceptor {
+
+    @Override
+    public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler, Map<String, Object> attributes) throws Exception {
+        String[] parts = request.getURI().getPath().split("/");
+        if(parts.length != 5) {
+            log.error("잘못된 웹소켓 연결 요청");
+            return false;
+        }
+        // 게시글 조회 관련 실시간 통신 요청일 경우
+        if(parts[2].equals("post")) {
+            try {
+                // 연결 요청 엔드 포인트에서 데이터 파싱
+                Long postId = Long.parseLong(parts[3]);
+                Long memberId = Long.parseLong(parts[4]);
+                // WebSocketHandler 에 전달될 속성 추가하기
+                attributes.put("postId", postId);
+                attributes.put("memberId", memberId);
+                return true;
+            } catch(NumberFormatException e) {
+                log.error("게시글 아이디, 멤버 아이디가 포함되어야 합니다.");
+                return false;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler, Exception exception) {
+        log.info("handshake success!");
+    }
+}

--- a/33ma3/src/main/java/softeer/be33ma3/websocket/HandShakeInterceptor.java
+++ b/33ma3/src/main/java/softeer/be33ma3/websocket/HandShakeInterceptor.java
@@ -27,6 +27,7 @@ public class HandShakeInterceptor implements HandshakeInterceptor {
                 Long postId = Long.parseLong(parts[3]);
                 Long memberId = Long.parseLong(parts[4]);
                 // WebSocketHandler 에 전달될 속성 추가하기
+                attributes.put("type", parts[2]);
                 attributes.put("postId", postId);
                 attributes.put("memberId", memberId);
                 return true;

--- a/33ma3/src/main/java/softeer/be33ma3/websocket/HandShakeInterceptor.java
+++ b/33ma3/src/main/java/softeer/be33ma3/websocket/HandShakeInterceptor.java
@@ -1,6 +1,7 @@
 package softeer.be33ma3.websocket;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
 import org.springframework.stereotype.Component;
@@ -18,6 +19,8 @@ public class HandShakeInterceptor implements HandshakeInterceptor {
         String[] parts = request.getURI().getPath().split("/");
         if(parts.length != 5) {
             log.error("잘못된 웹소켓 연결 요청");
+            response.setStatusCode(HttpStatus.FORBIDDEN);
+            response.getBody().write("웹소켓 연결 실패, 엔드포인트를 다시 확인해주세요.".getBytes());
             return false;
         }
         // 게시글 조회 관련 실시간 통신 요청일 경우
@@ -32,7 +35,9 @@ public class HandShakeInterceptor implements HandshakeInterceptor {
                 attributes.put("memberId", memberId);
                 return true;
             } catch(NumberFormatException e) {
-                log.error("게시글 아이디, 멤버 아이디가 포함되어야 합니다.");
+                log.error("웹소켓 연결 실패: 게시글 아이디, 멤버 아이디가 포함되어야 합니다.");
+                response.setStatusCode(HttpStatus.FORBIDDEN);
+                response.getBody().write("웹소켓 연결 실패, 게시글 아이디와 멤버 아이디를 포함해주세요.".getBytes());
                 return false;
             }
         }

--- a/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketConfig.java
+++ b/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketConfig.java
@@ -1,11 +1,10 @@
-package softeer.be33ma3.config;
+package softeer.be33ma3.websocket;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
-import softeer.be33ma3.controller.WebSocketHandler;
 
 @Configuration
 @EnableWebSocket
@@ -15,6 +14,6 @@ public class WebSocketConfig implements WebSocketConfigurer {
     private final WebSocketHandler webSocketHandler;
     @Override
     public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
-        registry.addHandler(webSocketHandler, "/connect/{postId}/{memberId}").setAllowedOrigins("*");
+        registry.addHandler(webSocketHandler, "/connect/{type}/{postId}/{memberId}").setAllowedOrigins("*");
     }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketConfig.java
+++ b/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketConfig.java
@@ -16,7 +16,7 @@ public class WebSocketConfig implements WebSocketConfigurer {
     private final HandshakeInterceptor handshakeInterceptor;
     @Override
     public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
-        registry.addHandler(webSocketHandler, "/connect/{type}/{postId}/{memberId}")
+        registry.addHandler(webSocketHandler, "/connect/{type}/{roomId}/{memberId}")
                 .setAllowedOrigins("*")
                 .addInterceptors(handshakeInterceptor);
     }

--- a/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketConfig.java
+++ b/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+import org.springframework.web.socket.server.HandshakeInterceptor;
 
 @Configuration
 @EnableWebSocket
@@ -12,8 +13,11 @@ import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry
 public class WebSocketConfig implements WebSocketConfigurer {
 
     private final WebSocketHandler webSocketHandler;
+    private final HandshakeInterceptor handshakeInterceptor;
     @Override
     public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
-        registry.addHandler(webSocketHandler, "/connect/{type}/{postId}/{memberId}").setAllowedOrigins("*");
+        registry.addHandler(webSocketHandler, "/connect/{type}/{postId}/{memberId}")
+                .setAllowedOrigins("*")
+                .addInterceptors(handshakeInterceptor);
     }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketHandler.java
+++ b/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketHandler.java
@@ -1,4 +1,4 @@
-package softeer.be33ma3.controller;
+package softeer.be33ma3.websocket;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -6,7 +6,6 @@ import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.TextWebSocketHandler;
-import softeer.be33ma3.service.WebSocketService;
 
 import java.io.IOException;
 
@@ -33,7 +32,11 @@ public class WebSocketHandler extends TextWebSocketHandler {
         } catch(Exception e) {
             log.error("연결 수립 후 에러 발생");
         } finally {
-            webSocketService.save(session);
+            // TODO: 올바른 요청 path인지 검증 필요
+            String[] attributes = session.getUri().getPath().split("/");
+            Long postId = Long.parseLong(attributes[2]);
+            Long memberId = Long.parseLong(attributes[3]);
+            webSocketService.save(postId, memberId, session);
         }
     }
     @Override
@@ -53,12 +56,12 @@ public class WebSocketHandler extends TextWebSocketHandler {
             log.error("실시간 데이터 전송 에러");
         }
     }
-
-    public void closeConnection(Long memberId) {
-        try {
-            webSocketService.closeConnection(memberId);
-        } catch (IOException e) {
-            log.error("연결 종료 에러");
-        }
-    }
+//
+//    public void closeConnection(Long memberId) {
+//        try {
+//            webSocketService.closeConnection(memberId);
+//        } catch (IOException e) {
+//            log.error("연결 종료 에러");
+//        }
+//    }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketHandler.java
+++ b/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketHandler.java
@@ -8,6 +8,7 @@ import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.TextWebSocketHandler;
 
 import java.io.IOException;
+import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
@@ -32,11 +33,14 @@ public class WebSocketHandler extends TextWebSocketHandler {
         } catch(Exception e) {
             log.error("연결 수립 후 에러 발생");
         } finally {
-            // TODO: 올바른 요청 path인지 검증 필요
-            String[] attributes = session.getUri().getPath().split("/");
-            Long postId = Long.parseLong(attributes[2]);
-            Long memberId = Long.parseLong(attributes[3]);
-            webSocketService.save(postId, memberId, session);
+            Map<String, Object> attributes = session.getAttributes();
+            String type = (String) attributes.get("type");
+            // 게시글 조회 관련 실시간 통신 요청일 경우
+            if(type.equals("post")) {
+                Long postId = (Long) attributes.get("postId");
+                Long memberId = (Long) attributes.get("memberId");
+                webSocketService.save(postId, memberId, session);
+            }
         }
     }
     @Override
@@ -56,12 +60,4 @@ public class WebSocketHandler extends TextWebSocketHandler {
             log.error("실시간 데이터 전송 에러");
         }
     }
-//
-//    public void closeConnection(Long memberId) {
-//        try {
-//            webSocketService.closeConnection(memberId);
-//        } catch (IOException e) {
-//            log.error("연결 종료 에러");
-//        }
-//    }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketHandler.java
+++ b/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketHandler.java
@@ -60,4 +60,8 @@ public class WebSocketHandler extends TextWebSocketHandler {
             log.error("실시간 데이터 전송 에러");
         }
     }
+
+    public void deletePostRoom(Long postId) {
+        webSocketService.deletePostRoom(postId);
+    }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketRepository.java
+++ b/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketRepository.java
@@ -1,4 +1,4 @@
-package softeer.be33ma3.repository;
+package softeer.be33ma3.websocket;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -20,12 +20,14 @@ public class WebSocketRepository {
     private final Map<Long, WebSocketSession> sessions = new ConcurrentHashMap<>();
 
     public void save(Long postId, Long memberId) {
-        Set<Long> members;
-        if(postRoom.containsKey(postId))
+        Set<Long> members = new HashSet<>();
+        System.out.println("here3");
+        if(postRoom.containsKey(postId)) {
             members = postRoom.get(postId);
-        else
-            members = new HashSet<>();
+        }
+        System.out.println("here1");
         members.add(memberId);
+        System.out.println("here2");
         postRoom.put(postId, members);
         log.info("{}번 게시글에 {}번 유저 입장", postId, memberId);
     }
@@ -33,6 +35,10 @@ public class WebSocketRepository {
     public void save(Long memberId, WebSocketSession webSocketSession) {
         sessions.put(memberId, webSocketSession);
         log.info("{}번 유저 웹소켓 세션 저장 성공", memberId);
+    }
+
+    public WebSocketSession findSessionByMemberId(Long memberId) {
+        return sessions.get(memberId);
     }
 
 //    public void save(Long memberId, WebSocketSession webSocketSession) {

--- a/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketRepository.java
+++ b/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketRepository.java
@@ -19,20 +19,16 @@ public class WebSocketRepository {
     // memberId : WebSocketSession
     private final Map<Long, WebSocketSession> sessions = new ConcurrentHashMap<>();
 
-    public void save(Long postId, Long memberId) {
+    public void saveMemberInPost(Long postId, Long memberId) {
         Set<Long> members = new HashSet<>();
-        System.out.println("here3");
-        if(postRoom.containsKey(postId)) {
+        if(postRoom.containsKey(postId))
             members = postRoom.get(postId);
-        }
-        System.out.println("here1");
         members.add(memberId);
-        System.out.println("here2");
         postRoom.put(postId, members);
         log.info("{}번 게시글에 {}번 유저 입장", postId, memberId);
     }
 
-    public void save(Long memberId, WebSocketSession webSocketSession) {
+    public void saveSessionWithMemberId(Long memberId, WebSocketSession webSocketSession) {
         sessions.put(memberId, webSocketSession);
         log.info("{}번 유저 웹소켓 세션 저장 성공", memberId);
     }
@@ -41,16 +37,21 @@ public class WebSocketRepository {
         return sessions.get(memberId);
     }
 
-//    public void save(Long memberId, WebSocketSession webSocketSession) {
-//        sessions.put(memberId, webSocketSession);
-//        log.info("WebSocketSession db : {}", sessions.size());
-//    }
-//
-//    public WebSocketSession findById(Long memberId) {
-//        return sessions.get(memberId);
-//    }
-//
-//    public void delete(Long memberId) {
-//        sessions.remove(memberId);
-//    }
+    public void deleteMemberInPost(Long postId, Long memberId) {
+        Set<Long> members = postRoom.get(postId);
+        if(members == null)
+            return;
+        members.remove(memberId);
+        if(members.isEmpty())
+            postRoom.remove(postId);
+    }
+
+    public void deleteSessionWithMemberId(Long memberId) {
+        sessions.remove(memberId);
+    }
+
+    // 게시글 만료시 호출
+    public void deletePostRoom(Long postId) {
+        postRoom.remove(postId);
+    }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketService.java
@@ -54,4 +54,8 @@ public class WebSocketService {
         webSocketRepository.deleteMemberInPost(postId, memberId);
         webSocketRepository.deleteSessionWithMemberId(memberId);
     }
+
+    public void deletePostRoom(Long postId) {
+        webSocketRepository.deletePostRoom(postId);
+    }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketService.java
@@ -1,14 +1,11 @@
-package softeer.be33ma3.service;
+package softeer.be33ma3.websocket;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
-import softeer.be33ma3.dto.request.PostCreateDto;
-import softeer.be33ma3.repository.WebSocketRepository;
 
 import java.io.IOException;
 
@@ -27,22 +24,26 @@ public class WebSocketService {
         session.sendMessage(textMessage);
     }
 
-    public void save(WebSocketSession session) {
-//        Long memberId = MemberService.getMemberId();
-//        webSocketRepository.save(memberId, session);
+    public void save(Long postId, Long memberId, WebSocketSession session) {
+        webSocketRepository.save(postId, memberId);
+        webSocketRepository.save(memberId, session);
     }
-    public void closeConnection(Long memberId) throws IOException {
-        WebSocketSession session = webSocketRepository.findById(memberId);
-        if(session == null)
-            return;
-        session.close(CloseStatus.NORMAL);
-        webSocketRepository.delete(memberId);
-    }
-
+//    public void closeConnection(Long memberId) throws IOException {
+//        WebSocketSession session = webSocketRepository.findById(memberId);
+//        if(session == null)
+//            return;
+//        session.close(CloseStatus.NORMAL);
+//        webSocketRepository.delete(memberId);
+//    }
+//
     // 데이터 (클래스 객체) 전송
     public void sendData(Long memberId, Object data) throws IOException {
         // 클라이언트에 해당하는 세션 가져오기
-        WebSocketSession session = webSocketRepository.findById(memberId);
+        WebSocketSession session = webSocketRepository.findSessionByMemberId(memberId);
+        if(session == null) {
+            log.info("웹 소켓 연결이 되어있지 않음");
+            return;
+        }
         // data 직렬화
         String jsonString = objectMapper.writeValueAsString(data);
         // 데이터 전송

--- a/33ma3/src/test/java/softeer/be33ma3/repository/OfferRepositoryTest.java
+++ b/33ma3/src/test/java/softeer/be33ma3/repository/OfferRepositoryTest.java
@@ -1,0 +1,94 @@
+package softeer.be33ma3.repository;
+
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import softeer.be33ma3.domain.Center;
+import softeer.be33ma3.domain.Offer;
+import softeer.be33ma3.domain.Post;
+import softeer.be33ma3.dto.request.PostCreateDto;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class OfferRepositoryTest {
+
+    @Autowired
+    private OfferRepository offerRepository;
+    @Autowired
+    private PostRepository postRepository;
+    @Autowired
+    private CenterRepository centerRepository;
+
+    @BeforeEach
+    void setUp() {
+        // post 저장
+        PostCreateDto postCreateDto = new PostCreateDto("승용차", "제네시스", 3,
+                "서울시 강남구", "기스, 깨짐", "오일 교체, 타이어 교체",
+                new ArrayList<>(), "게시글");
+        Post post1 = Post.createPost(postCreateDto, null, null);
+        Post post2 = Post.createPost(postCreateDto, null, null);
+        Post savedPost1 = postRepository.save(post1);
+        Post savedPost2 = postRepository.save(post2);
+        // center 저장
+        Center center1 = Center.createCenter("서비스센터1", 0, 0, null);
+        Center center2 = Center.createCenter("서비스센터2", 0, 0, null);
+        Center center3 = Center.createCenter("서비스센터3", 0, 0, null);
+        Center savedCenter1 = centerRepository.save(center1);
+        Center savedCenter2 = centerRepository.save(center2);
+        Center savedCenter3 = centerRepository.save(center3);
+
+        // offer 저장
+        Offer offer1 = createOffer(1, "offer1", savedPost1, savedCenter1);
+        Offer offer2 = createOffer(2, "offer2", savedPost1, savedCenter2);
+        Offer offer3 = createOffer(3, "offer3", savedPost2, savedCenter3);
+        offerRepository.saveAll(List.of(offer1, offer2, offer3));
+    }
+
+    @AfterEach
+    void tearDown() {
+        offerRepository.deleteAllInBatch();
+        centerRepository.deleteAllInBatch();
+        postRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("post id를 이용하여 게시글에 속해있는 모든 댓글 목록을 가져올 수 있다.")
+    @Test
+    void findByPost_PostId() {
+        // given / when
+        List<Offer> offerList = offerRepository.findByPost_PostId(1L);
+        // then
+        assertThat(offerList).hasSize(2)
+                .extracting("price", "contents")
+                .contains(
+                        tuple(1, "offer1"),
+                        tuple(2, "offer2")
+                );
+    }
+
+    @DisplayName("해당 게시글에서 해당하는 서비스 센터가 작성한 댓글을 반환할 수 있다.")
+    @Test
+    void findByPost_PostIdAndCenter_CenterId() {
+        // given / when
+        Optional<Offer> actual = offerRepository.findByPost_PostIdAndCenter_CenterId(1L, 1L);
+        // then
+        assertThat(actual).isPresent()
+                        .get().extracting("price", "contents")
+                        .containsExactly(1, "offer1");
+    }
+
+    Offer createOffer(int price, String contents, Post post, Center center) {
+        return Offer.builder()
+                .price(price)
+                .contents(contents)
+                .post(post)
+                .center(center).build();
+    }
+}


### PR DESCRIPTION
## 구현 내용
- [x] 웹 소켓 연결 요청 엔드 포인트 수정 -> 이후 문의 채팅시에도 다른 엔드 포인트 요청을 보낼 수 있도록 고려
- [x] HandShakeInterceptor 구현 -> handshake 전 적절한 연결 요청인지 판단 후 연결 허용
- [x] 웹 소켓 세션 저장 방식 변경 -> 게시글 세부사항 화면 진입 시 웹 소켓 연결 요청, 해당 화면에서 벗어날 시 연결 종료로 방식을 변경하였으므로, 게시글을 기준으로 해당 게시글을 보고있는 유저들의 id를 저장하도록 ConcurrentMap 구성 변경. 각 클라이언트들의 세션은 일대일 대응되는 map을 추가로 두어 저장, 관리하도록 함
- [x] 프론트 측에서 전송받은 메세지를 역직렬화하여 연결이 끊어진 유저에 대한 정보를 매핑, 이를 바탕으로 map 저장소 업데이트
- [x] 연결 close는 프론트 측에서 하므로 서버가 직접 close하는 부분 삭제 

## 고민 사항
1. 이후 채팅 시스템도 구현할 예정인 만큼, 추후 채팅을 위한 웹 소켓 연결 요청에 엔드 포인트를 재사용할 것을 고려하여 엔드 포인트를 새롭게 작성하였다. 변경된 엔드 포인트는 "/connect/{type}/{roomId}/{memberId}로, 게시글 관련 요청일 경우 type에 "post"를 받는다. 채팅의 경우 "chat"를 받는 등으로 구분될 수 있을 것이다. 
2. 마찬가지로 webSocketRepository 상의 네이밍 또한 이후 채팅 시스템으로의 확장성을 고려하였다.
3. 웹소켓 연결을 프론트 측에서 직접 끊다보니 서버는 해당 멤버와의 연결이 끊어졌는지 알지 못한다. 그럴 경우 연결이 끊어진 멤버에 대해서도 Map 저장소에 불필요한 데이터가 저장되어 있게 된다. 따라서 프론트 측이 연결을 끊으면 서버측에 해당 멤버에 대한 정보를 전송하여, 이를 바탕으로 Map 저장소에서 데이터를 제거하기로 했다. 
물론 연결이 끊어지면 webSocketHandler 상의 afterConnectionClosed 메소드가 자동으로 호출되어 끊어진 웹소켓 세션을 알 수 있다. 하지만 이를 이용할 경우 세션만을 이용하여 두 개의 Map 저장소에서 해당하는 element를 제거해야하는데, 두 경우 모두 key가 아닌 value를 이용한 삭제를 해야하는 문제가 있다. 이 방식보다 프론트 측으로부터 key 값에 해당하는 정보를 전송받는 방식을 채택하였다. 

## 기타
게시글 마감 시간이 지나 마감된 경우 webSocketRepository 상의 postRoom 에서 게시글에 해당하는 element를 제거해줘야 함