### PR TITLE
필터링 전 전체 게시글 목록 조회 기능 구현 #80

### DIFF
--- a/33ma3/src/main/java/softeer/be33ma3/controller/OfferController.java
+++ b/33ma3/src/main/java/softeer/be33ma3/controller/OfferController.java
@@ -56,10 +56,7 @@ public class OfferController {
                                          @RequestBody @Valid OfferCreateDto offerCreateDto,
                                          @Schema(hidden = true) @CurrentUser Member member) {
         offerService.createOffer(postId, offerCreateDto, member);
-        // 글 작성자에게 업데이트 된 댓글 리스트 보내기
-        offerService.sendOfferList2Writer(postId);
-        // 댓글 작성자들에게 업데이트된 평균 견적 제시 가격 보내기
-        offerService.sendAvgPrice2Centers(postId);
+        offerService.sendAboutOfferUpdate(postId);
         return ResponseEntity.ok(SingleResponse.success("입찰 성공"));
     }
 
@@ -80,10 +77,7 @@ public class OfferController {
                                          @RequestBody @Valid OfferCreateDto offerCreateDto,
                                          @Schema(hidden = true) @CurrentUser Member member) {
         offerService.updateOffer(postId, offerId, offerCreateDto, member);
-        // 글 작성자에게 업데이트 된 댓글 리스트 보내기
-        offerService.sendOfferList2Writer(postId);
-        // 댓글 작성자들에게 업데이트된 평균 견적 제시 가격 보내기
-        offerService.sendAvgPrice2Centers(postId);
+        offerService.sendAboutOfferUpdate(postId);
         return ResponseEntity.ok(SingleResponse.success("댓글 수정 성공"));
     }
 
@@ -102,10 +96,7 @@ public class OfferController {
                                          @PathVariable("offer_id") Long offerId,
                                          @Schema(hidden = true) @CurrentUser Member member) {
         offerService.deleteOffer(postId, offerId, member);
-        // 글 작성자에게 업데이트 된 댓글 리스트 보내기
-        offerService.sendOfferList2Writer(postId);
-        // 댓글 작성자들에게 업데이트된 평균 견적 제시 가격 보내기
-        offerService.sendAvgPrice2Centers(postId);
+        offerService.sendAboutOfferUpdate(postId);
         return ResponseEntity.ok(SingleResponse.success("댓글 삭제 성공"));
     }
 

--- a/33ma3/src/main/java/softeer/be33ma3/controller/PostController.java
+++ b/33ma3/src/main/java/softeer/be33ma3/controller/PostController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import softeer.be33ma3.domain.Member;
 import softeer.be33ma3.dto.request.PostCreateDto;
+import softeer.be33ma3.dto.response.PostThumbnailDto;
 import softeer.be33ma3.jwt.CurrentUser;
 import softeer.be33ma3.response.DataResponse;
 import softeer.be33ma3.response.SingleResponse;
@@ -31,6 +32,19 @@ import java.util.List;
 @RequestMapping("/post")
 public class PostController {
     private final PostService postService;
+
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "게시글 목록 조회 성공", content = @Content(schema = @Schema(implementation = DataResponse.class))),
+            @ApiResponse(responseCode = "400", description = "존재하지 않는 센터", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
+            @ApiResponse(responseCode = "500", description = "Internal Server Error",
+                    content = @Content(schema = @Schema(implementation = SingleResponse.class)))
+    })
+    @Operation(summary = "게시글 목록 조회", description = "게시글 목록 조회 메서드 입니다.")
+    @GetMapping("")
+    public ResponseEntity<?> showPosts(@Schema(hidden = true) @CurrentUser Member member) {
+        List<PostThumbnailDto> postThumbnailDtos = postService.showPosts(member);
+        return ResponseEntity.ok().body(DataResponse.success("게시글 목록 조회 성공", postThumbnailDtos));
+    }
 
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "게시글 작성 성공", content = @Content(schema = @Schema(implementation = DataResponse.class))),

--- a/33ma3/src/main/java/softeer/be33ma3/controller/PostController.java
+++ b/33ma3/src/main/java/softeer/be33ma3/controller/PostController.java
@@ -40,7 +40,7 @@ public class PostController {
                     content = @Content(schema = @Schema(implementation = SingleResponse.class)))
     })
     @Operation(summary = "게시글 목록 조회", description = "게시글 목록 조회 메서드 입니다.")
-    @GetMapping("")
+    @GetMapping
     public ResponseEntity<?> showPosts(@Schema(hidden = true) @CurrentUser Member member) {
         List<PostThumbnailDto> postThumbnailDtos = postService.showPosts(member);
         return ResponseEntity.ok().body(DataResponse.success("게시글 목록 조회 성공", postThumbnailDtos));

--- a/33ma3/src/main/java/softeer/be33ma3/dto/response/OfferDetailDto.java
+++ b/33ma3/src/main/java/softeer/be33ma3/dto/response/OfferDetailDto.java
@@ -16,6 +16,9 @@ public class OfferDetailDto implements Comparable<OfferDetailDto> {
     @Schema(description = "견적 아이디", example = "1")
     private Long offerId;
 
+    @Schema(description = "견적을 작성한 센터의 멤버 아이디", example = "1")
+    private Long memberId;
+
     @Schema(description = "센터 이름", example = "현대자동차 강남점")
     private String centerName;
 
@@ -32,6 +35,7 @@ public class OfferDetailDto implements Comparable<OfferDetailDto> {
     public static OfferDetailDto fromEntity(Offer offer) {
         return OfferDetailDto.builder()
                 .offerId(offer.getOfferId())
+                .memberId(offer.getCenter().getMember().getMemberId())
                 .centerName(offer.getCenter().getCenterName())
                 .price(offer.getPrice())
                 .contents(offer.getContents())

--- a/33ma3/src/main/java/softeer/be33ma3/dto/response/PostDetailDto.java
+++ b/33ma3/src/main/java/softeer/be33ma3/dto/response/PostDetailDto.java
@@ -74,7 +74,7 @@ public class PostDetailDto {
     }
 
     // 구분자 콤마로 문자열 파싱 후 각각의 토큰에서 공백 제거 후 리스트 반환
-    private static List<String> stringCommaParsing(String inputString) {
+    public static List<String> stringCommaParsing(String inputString) {
         if(inputString.isEmpty())
             return List.of();
         return Arrays.stream(inputString.split(","))
@@ -82,14 +82,14 @@ public class PostDetailDto {
                 .toList();
     }
 
-    private static Duration calculateDuration(Post post) {
+    public static Duration calculateDuration(Post post) {
         LocalDateTime endTime = post.getCreateTime().plusDays(post.getDeadline());
         endTime = endTime.withHour(23).withMinute(59).withSecond(59);
         return Duration.between(LocalDateTime.now(), endTime);
     }
 
-    // 마감 시간까지 남은 시간:분:초를 반환
-    private static int calculateRemainTime(Duration duration) {
+    // 마감 시간까지 남은 시간을 초 단위로 반환
+    public static int calculateRemainTime(Duration duration) {
         return (int) duration.toSeconds();
     }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/dto/response/PostDetailDto.java
+++ b/33ma3/src/main/java/softeer/be33ma3/dto/response/PostDetailDto.java
@@ -29,8 +29,8 @@ public class PostDetailDto {
     @Schema(description = "남은 기한", example = "3")
     private int dDay;
 
-    @Schema(description = "당일 남은 시간", example = "11:32:51")
-    private LocalTime remainTime;
+    @Schema(description = "당일 남은 시간 (초)", example = "12345")
+    private int remainTime;
 
     @Schema(description = "지역 명", example = "강남구")
     private String regionName;
@@ -54,7 +54,7 @@ public class PostDetailDto {
         List<String> imageList = post.getImages().stream().map(Image::getLink).toList();
         Duration duration = calculateDuration(post);
         int dDay = -1;
-        LocalTime remainTime = null;
+        int remainTime = 0;
         if(!post.isDone() && !duration.isNegative())        // 아직 마감 시간 전
             dDay = (int)duration.toDays();
         if(dDay == 0)
@@ -89,11 +89,8 @@ public class PostDetailDto {
     }
 
     // 마감 시간까지 남은 시간:분:초를 반환
-    private static LocalTime calculateRemainTime(Duration duration) {
-        int hours = (int)duration.toHours();
-        int minutes = duration.toMinutesPart();
-        int seconds = duration.toSecondsPart();
-        return LocalTime.of(hours, minutes, seconds);
+    private static int calculateRemainTime(Duration duration) {
+        return (int) duration.toSeconds();
     }
 }
 

--- a/33ma3/src/main/java/softeer/be33ma3/dto/response/PostThumbnailDto.java
+++ b/33ma3/src/main/java/softeer/be33ma3/dto/response/PostThumbnailDto.java
@@ -1,0 +1,64 @@
+package softeer.be33ma3.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import softeer.be33ma3.domain.Image;
+import softeer.be33ma3.domain.Post;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class PostThumbnailDto implements Comparable<PostThumbnailDto> {
+
+    private Long postId;
+    private String modelName;
+    private LocalDateTime createTime;
+    private int dDay;
+    private int remainTime;
+    private List<String> imageList;
+    private List<String> repairList;
+    private List<String> tuneUpList;
+    private int offerCount;
+
+    // 생성 시간 기준으로 최신순 정렬
+    @Override
+    public int compareTo(PostThumbnailDto other) {
+        if(this.createTime.isAfter(other.getCreateTime()))
+            return -1;
+        else if(this.createTime.isBefore(other.getCreateTime()))
+            return 1;
+        // createTime이 동일할 경우
+        if(postId > other.getPostId())
+            return -1;
+        else
+            return 1;
+    }
+
+    // Post Entity -> PostThumbnailDto 변환
+    public static PostThumbnailDto fromEntity(Post post, int offerCount) {
+        List<String> imageList = post.getImages().stream().map(Image::getLink).toList();
+        List<String> repairList = PostDetailDto.stringCommaParsing(post.getRepairService());
+        List<String> tuneUpList = PostDetailDto.stringCommaParsing(post.getTuneUpService());
+        Duration duration = PostDetailDto.calculateDuration(post);
+        int dDay = -1;
+        int remainTime = 0;
+        if(!post.isDone() && !duration.isNegative())        // 아직 마감 시간 전
+            dDay = (int)duration.toDays();
+        if(dDay == 0)
+            remainTime = PostDetailDto.calculateRemainTime(duration);
+
+        return PostThumbnailDto.builder()
+                .postId(post.getPostId())
+                .modelName(post.getModelName())
+                .createTime(post.getCreateTime())
+                .dDay(dDay)
+                .remainTime(remainTime)
+                .repairList(repairList)
+                .tuneUpList(tuneUpList)
+                .imageList(imageList)
+                .offerCount(offerCount).build();
+    }
+}

--- a/33ma3/src/main/java/softeer/be33ma3/dto/response/PostThumbnailDto.java
+++ b/33ma3/src/main/java/softeer/be33ma3/dto/response/PostThumbnailDto.java
@@ -7,6 +7,7 @@ import softeer.be33ma3.domain.Post;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 @Getter
@@ -15,7 +16,8 @@ public class PostThumbnailDto implements Comparable<PostThumbnailDto> {
 
     private Long postId;
     private String modelName;
-    private LocalDateTime createTime;
+    private LocalDateTime rawCreateTime;
+    private String createTime;
     private int dDay;
     private int remainTime;
     private List<String> imageList;
@@ -26,9 +28,9 @@ public class PostThumbnailDto implements Comparable<PostThumbnailDto> {
     // 생성 시간 기준으로 최신순 정렬
     @Override
     public int compareTo(PostThumbnailDto other) {
-        if(this.createTime.isAfter(other.getCreateTime()))
+        if(this.rawCreateTime.isAfter(other.getRawCreateTime()))
             return -1;
-        else if(this.createTime.isBefore(other.getCreateTime()))
+        else if(this.rawCreateTime.isBefore(other.getRawCreateTime()))
             return 1;
         // createTime이 동일할 경우
         if(postId > other.getPostId())
@@ -53,12 +55,18 @@ public class PostThumbnailDto implements Comparable<PostThumbnailDto> {
         return PostThumbnailDto.builder()
                 .postId(post.getPostId())
                 .modelName(post.getModelName())
-                .createTime(post.getCreateTime())
+                .rawCreateTime(post.getCreateTime())
+                .createTime(createTimeFormatting(post.getCreateTime()))
                 .dDay(dDay)
                 .remainTime(remainTime)
                 .repairList(repairList)
                 .tuneUpList(tuneUpList)
                 .imageList(imageList)
                 .offerCount(offerCount).build();
+    }
+
+    private static String createTimeFormatting(LocalDateTime rawCreateTime) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+        return rawCreateTime.format(formatter);
     }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/repository/PostPerCenterRepository.java
+++ b/33ma3/src/main/java/softeer/be33ma3/repository/PostPerCenterRepository.java
@@ -1,7 +1,13 @@
 package softeer.be33ma3.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import softeer.be33ma3.domain.Post;
 import softeer.be33ma3.domain.PostPerCenter;
 
+import java.util.List;
+
 public interface PostPerCenterRepository extends JpaRepository<PostPerCenter, Long> {
+    @Query("SELECT ppc.post FROM PostPerCenter ppc WHERE ppc.center.centerId = :centerId")
+    List<Post> findPostsByCenter_CenterId(Long centerId);
 }

--- a/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
@@ -133,7 +133,7 @@ public class OfferService {
 
         if(stats.getSum() == 0)
             return 0;
-        return stats.getAverage();
+        return Math.round(stats.getAverage() * 10) / 10.0;      // 소수점 첫째 자리까지 반올림
     }
 
     // 게시글에 해당하는 견적 제시 댓글 리스트 실시간 전송

--- a/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
@@ -19,6 +19,7 @@ import softeer.be33ma3.response.DataResponse;
 
 import java.util.IntSummaryStatistics;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -136,25 +137,35 @@ public class OfferService {
         return Math.round(stats.getAverage() * 10) / 10.0;      // 소수점 첫째 자리까지 반올림
     }
 
-    // 게시글에 해당하는 견적 제시 댓글 리스트 실시간 전송
-    public void sendOfferList2Writer(Long postId) {
+    public void sendAboutOfferUpdate(Long postId) {
         // 1. 해당 게시글 가져오기
         Post post = postRepository.findById(postId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글"));
         // 2. 글 작성자 아이디 가져오기
-        Long memberId = post.getMember().getMemberId();
-        // 3. 게시글에 속해있는 댓글 목록 가져오기
+        Long writerId = post.getMember().getMemberId();
+        // 3. 글 작성자에게 업데이트된 댓글 목록 실시간 전송
+        sendOfferList2Writer(postId, writerId);
+        // 4. 그 외 접속한 유저에게 업데이트된 평균 제시 가격 실시간 전송
+        sendAvgPrice2Others(postId, writerId);
+    }
+
+    // 게시글에 해당하는 견적 제시 댓글 리스트 실시간 전송
+    public void sendOfferList2Writer(Long postId, Long memberId) {
+        // 1. 게시글에 속해있는 댓글 목록 가져오기
         List<Offer> offerList = offerRepository.findByPost_PostId(postId);
         List<OfferDetailDto> offerDetailList = OfferDetailDto.fromEntityList(offerList);
-        // 4. 전송하기
+        // 1. 전송하기
         webSocketHandler.sendData2Client(memberId, offerDetailList);
     }
 
-    // 게시글에 견적을 작성한 모든 서비스 센터들에게 평균 견적 제시 가격 실시간 전송
-    public void sendAvgPrice2Centers(Long postId) {
+    // 해당 게시글 화면을 보고 있는 모든 유저들에게 평균 견적 제시 가격 실시간 전송
+    public void sendAvgPrice2Others(Long postId, Long writerId) {
         // 1. 해당 게시글에 달린 모든 견적 가져오기
         List<Offer> offerList = offerRepository.findByPost_PostId(postId);
-        // 2. 견적 작성자의 member id 가져오기
-        List<Long> memberList = findMemberIdsWithOfferList(offerList);
+        // 2. 해당 게시글을 보고 있는 모든 유저들 가져오기 (글 작성자도 포함되어있을 경우 제외시키기)
+        Set<Long> memberList = webSocketHandler.findAllMemberInPost(postId);
+        memberList = memberList.stream()
+                .filter(memberId -> !memberId.equals(writerId))
+                .collect(Collectors.toSet());
         // 3. 평균 견적 가격 계산하기
         AvgPriceDto avgPriceDto = new AvgPriceDto(calculateAvgPrice(offerList));
         // 4. 전송하기

--- a/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
@@ -91,7 +91,6 @@ public class PostService {
         // 해당 게시글의 견적 모두 가져오기
         List<Offer> offerList = offerRepository.findByPost_PostId(postId);
         double avgPrice = OfferService.calculateAvgPrice(offerList);
-        avgPrice = Math.round(avgPrice * 10) / 10.0;      // 소수점 첫째 자리까지 반올림
         PostWithAvgPriceDto postWithAvgPriceDto = new PostWithAvgPriceDto(postDetailDto, avgPrice);
         // 견적을 작성한 이력이 있는 서비스 센터의 접근일 경우 작성한 견적 가져오기
         OfferDetailDto offerDetailDto = getCenterOffer(postId, member);

--- a/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
@@ -38,12 +38,10 @@ public class PostService {
             List<Post> posts = postRepository.findAll();
             return fromPostList(posts);
         }
-        // 2. 서비스 센터일 경우 -> 센터에 해당하는 마감 전 게시글만 가져오기
+        // 2. 서비스 센터일 경우 -> 센터에 해당하는 게시글만 가져오기
         Center center = centerRepository.findByMember_MemberId(member.getMemberId()).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 센터"));
         List<Post> posts = postPerCenterRepository.findPostsByCenter_CenterId(center.getCenterId());
-        List<Post> notDonePosts = posts.stream()
-                .filter(post -> !post.isDone()).toList();
-        return fromPostList(notDonePosts);
+        return fromPostList(posts);
     }
 
     // List<Post> -> List<PostThumbnailDto>로 변환

--- a/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
@@ -48,11 +48,13 @@ public class PostService {
 
     // List<Post> -> List<PostThumbnailDto>로 변환
     private List<PostThumbnailDto> fromPostList(List<Post> posts) {
-        return posts.stream()
+        List<PostThumbnailDto> postThumbnailDtos = new ArrayList<>(posts.stream()
                 .map(post -> {
                     int offerCount = countOfferNum(post.getPostId());
                     return PostThumbnailDto.fromEntity(post, offerCount);
-                }).toList();
+                }).toList());
+        Collections.sort(postThumbnailDtos);
+        return postThumbnailDtos;
     }
 
     // 해당 게시글에 달린 댓글 개수 반환

--- a/33ma3/src/main/java/softeer/be33ma3/service/SchedulingService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/SchedulingService.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import softeer.be33ma3.domain.Post;
 import softeer.be33ma3.repository.PostRepository;
+import softeer.be33ma3.websocket.WebSocketHandler;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -17,6 +18,7 @@ import java.util.List;
 @Service
 public class SchedulingService {
     private final PostRepository postRepository;
+    private final WebSocketHandler webSocketHandler;
 
     @Scheduled(cron = "0 1 0 * * * ", zone = "Asia/Seoul") //매 00시 01분 마다 실행
     @Transactional
@@ -33,6 +35,7 @@ public class SchedulingService {
 
             if (currentDate.isAfter(deadlineTime)) {
                 post.setDone();
+                webSocketHandler.deletePostRoom(post.getPostId());
             }
         }
     }

--- a/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketHandler.java
+++ b/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketHandler.java
@@ -9,6 +9,7 @@ import org.springframework.web.socket.handler.TextWebSocketHandler;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Set;
 
 @Component
 @RequiredArgsConstructor
@@ -63,5 +64,8 @@ public class WebSocketHandler extends TextWebSocketHandler {
 
     public void deletePostRoom(Long postId) {
         webSocketService.deletePostRoom(postId);
+    }
+    public Set<Long> findAllMemberInPost(Long postId) {
+        return webSocketService.findAllMemberInPost(postId);
     }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketRepository.java
+++ b/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketRepository.java
@@ -19,6 +19,10 @@ public class WebSocketRepository {
     // memberId : WebSocketSession
     private final Map<Long, WebSocketSession> sessions = new ConcurrentHashMap<>();
 
+    public Set<Long> findAllMemberInPost(Long postId) {
+        return postRoom.get(postId);
+    }
+
     public void saveMemberInPost(Long postId, Long memberId) {
         Set<Long> members = new HashSet<>();
         if(postRoom.containsKey(postId))
@@ -48,6 +52,7 @@ public class WebSocketRepository {
 
     public void deleteSessionWithMemberId(Long memberId) {
         sessions.remove(memberId);
+        log.info("세션 삭제 완료! 세션 저장소 크키: {}", sessions.size());
     }
 
     // 게시글 만료시 호출

--- a/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketService.java
@@ -8,6 +8,7 @@ import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 
 import java.io.IOException;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -56,5 +57,10 @@ public class WebSocketService {
 
     public void deletePostRoom(Long postId) {
         webSocketRepository.deletePostRoom(postId);
+    }
+
+    // 해당 게시글에 접속해있는 유저 목록 반환
+    public Set<Long> findAllMemberInPost(Long postId) {
+        return webSocketRepository.findAllMemberInPost(postId);
     }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketService.java
@@ -25,7 +25,6 @@ public class WebSocketService {
             closePostConnection(exitMember.getRoomId(), exitMember.getMemberId());
         }
 
-
         log.info("메세지 수신 성공: {}", payload); // 수신한 메세지 log
         TextMessage textMessage = new TextMessage("메세지 수신 성공");
         session.sendMessage(textMessage);


### PR DESCRIPTION
## 구현 내용
- [x] 접근 유저가 로그인하지 않았거나 서비스 센터가 아닌 경우: 전체 게시글을 가져와 목록 반환
- [x] 접근 유저가 서비스 센터일 경우: 센터에게 할당된 게시글 목록 반환
- [x] 마감 여부는 dday가 -1일 경우로 구분
- [x] 게시글 마감 시 webSocketRepository 상의 postRoom 저장소에서 해당 게시글 element를 삭제

## 고민 사항
PostThumbnailDto에서 필요한 메소드가 PostDetailDto 클래스 내에 위치해있어서, 이를 해당 위치 그대로 두고 PostThumbnailDto에서 사용해도 의미상 괜찮을지 생각해보았다. 
PostThumbnailDto가 사실상 게시글 세부사항에서 보여줄 내용을 썸네일 형식으로 보여주는 객체이기 때문에, 괜찮을 것 같다고 판단했다.

## 기타
