### PR TITLE
게시글 관련 추가 보완 #109

### DIFF
--- a/33ma3/src/main/java/softeer/be33ma3/controller/PostController.java
+++ b/33ma3/src/main/java/softeer/be33ma3/controller/PostController.java
@@ -62,7 +62,7 @@ public class PostController {
 
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "게시글 조회 완료", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
-            @ApiResponse(responseCode = "400", description = "존재하지 않는 게시글" + "<br>존재하지 않는 서비스 센터",
+            @ApiResponse(responseCode = "400", description = "존재하지 않는 게시글" + "<br>존재하지 않는 서비스 센터" + "<br>경매 중인 게시글을 보려면 로그인해주세요.",
                     content = @Content(schema = @Schema(implementation = SingleResponse.class)))
     })
     @Operation(summary = "게시글 조회", description = "게시글 조회 메서드 입니다.")

--- a/33ma3/src/main/java/softeer/be33ma3/controller/PostController.java
+++ b/33ma3/src/main/java/softeer/be33ma3/controller/PostController.java
@@ -62,8 +62,8 @@ public class PostController {
 
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "게시글 조회 완료", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
-            @ApiResponse(responseCode = "400", description = "존재하지 않는 게시글" + "<br>존재하지 않는 서비스 센터" + "<br>경매 중인 게시글을 보려면 로그인해주세요.",
-                    content = @Content(schema = @Schema(implementation = SingleResponse.class)))
+            @ApiResponse(responseCode = "400", description = "존재하지 않는 게시글" + "<br>존재하지 않는 서비스 센터", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
+            @ApiResponse(responseCode = "401", description = "경매 중인 게시글을 보려면 로그인해주세요.", content = @Content(schema = @Schema(implementation = SingleResponse.class)))
     })
     @Operation(summary = "게시글 조회", description = "게시글 조회 메서드 입니다.")
     @Parameter(name = "post_id", description = "조회할 게시글 id", required = true, example = "1", in = ParameterIn.PATH)

--- a/33ma3/src/main/java/softeer/be33ma3/dto/response/PostDetailDto.java
+++ b/33ma3/src/main/java/softeer/be33ma3/dto/response/PostDetailDto.java
@@ -19,6 +19,9 @@ public class PostDetailDto {
     @Schema(description = "게시글 아이디", example = "1")
     private Long postId;
 
+    @Schema(description = "작성자 아이디", example = "1")
+    private Long writerId;
+
     @Schema(description = "차종", example = "승용차")
     private String carType;
 
@@ -61,6 +64,7 @@ public class PostDetailDto {
 
         return PostDetailDto.builder()
                 .postId(post.getPostId())
+                .writerId(post.getMember().getMemberId())
                 .carType(post.getCarType())
                 .modelName(post.getModelName())
                 .dDay(dDay)

--- a/33ma3/src/main/java/softeer/be33ma3/dto/response/PostThumbnailDto.java
+++ b/33ma3/src/main/java/softeer/be33ma3/dto/response/PostThumbnailDto.java
@@ -14,7 +14,7 @@ import java.util.List;
 @Getter
 @Builder
 @Schema(description = "게시글 목록 미리보기 응답 DTO")
-public class PostThumbnailDto implements Comparable<PostThumbnailDto> {
+public class PostThumbnailDto {
     @Schema(description = "게시글 아이디", example = "1")
     private Long postId;
 
@@ -23,9 +23,6 @@ public class PostThumbnailDto implements Comparable<PostThumbnailDto> {
 
     @Schema(description = "모델명", example = "제네시스")
     private String modelName;
-
-    @Schema(description = "게시글 생성 시간 LocalDateTime", example = "2024-02-06T02:23:25.043239")
-    private LocalDateTime rawCreateTime;
 
     @Schema(description = "게시글 생성 시간 문자열", example = "2024.02.06")
     private String createTime;
@@ -48,20 +45,6 @@ public class PostThumbnailDto implements Comparable<PostThumbnailDto> {
     @Schema(description = "댓글 개수", example = "1")
     private int offerCount;
 
-    // 생성 시간 기준으로 최신순 정렬
-    @Override
-    public int compareTo(PostThumbnailDto other) {
-        if(this.rawCreateTime.isAfter(other.getRawCreateTime()))
-            return -1;
-        else if(this.rawCreateTime.isBefore(other.getRawCreateTime()))
-            return 1;
-        // createTime이 동일할 경우
-        if(postId > other.getPostId())
-            return -1;
-        else
-            return 1;
-    }
-
     // Post Entity -> PostThumbnailDto 변환
     public static PostThumbnailDto fromEntity(Post post, int offerCount) {
         List<String> imageList = post.getImages().stream().map(Image::getLink).toList();
@@ -79,7 +62,6 @@ public class PostThumbnailDto implements Comparable<PostThumbnailDto> {
                 .postId(post.getPostId())
                 .writerId(post.getMember().getMemberId())
                 .modelName(post.getModelName())
-                .rawCreateTime(post.getCreateTime())
                 .createTime(createTimeFormatting(post.getCreateTime()))
                 .dDay(dDay)
                 .remainTime(remainTime)

--- a/33ma3/src/main/java/softeer/be33ma3/dto/response/PostThumbnailDto.java
+++ b/33ma3/src/main/java/softeer/be33ma3/dto/response/PostThumbnailDto.java
@@ -1,5 +1,6 @@
 package softeer.be33ma3.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 import softeer.be33ma3.domain.Image;
@@ -12,17 +13,39 @@ import java.util.List;
 
 @Getter
 @Builder
+@Schema(description = "게시글 목록 미리보기 응답 DTO")
 public class PostThumbnailDto implements Comparable<PostThumbnailDto> {
-
+    @Schema(description = "게시글 아이디", example = "1")
     private Long postId;
+
+    @Schema(description = "작성자 아이디", example = "1")
+    private Long writerId;
+
+    @Schema(description = "모델명", example = "제네시스")
     private String modelName;
+
+    @Schema(description = "게시글 생성 시간 LocalDateTime", example = "2024-02-06T02:23:25.043239")
     private LocalDateTime rawCreateTime;
+
+    @Schema(description = "게시글 생성 시간 문자열", example = "2024.02.06")
     private String createTime;
+
+    @Schema(description = "남은 기한", example = "3")
     private int dDay;
+
+    @Schema(description = "당일 남은 시간 (초)", example = "12345")
     private int remainTime;
+
+    @Schema(description = "이미지 url 리스트", example = "[aaa.png, bbb.png]")
     private List<String> imageList;
+
+    @Schema(description = "수리 서비스 리스트", example = "[깨짐, 기스]")
     private List<String> repairList;
+
+    @Schema(description = "정비 서비스 리스트", example = "[타이어 교체, 오일 교체]")
     private List<String> tuneUpList;
+
+    @Schema(description = "댓글 개수", example = "1")
     private int offerCount;
 
     // 생성 시간 기준으로 최신순 정렬
@@ -54,6 +77,7 @@ public class PostThumbnailDto implements Comparable<PostThumbnailDto> {
 
         return PostThumbnailDto.builder()
                 .postId(post.getPostId())
+                .writerId(post.getMember().getMemberId())
                 .modelName(post.getModelName())
                 .rawCreateTime(post.getCreateTime())
                 .createTime(createTimeFormatting(post.getCreateTime()))

--- a/33ma3/src/main/java/softeer/be33ma3/repository/PostPerCenterRepository.java
+++ b/33ma3/src/main/java/softeer/be33ma3/repository/PostPerCenterRepository.java
@@ -8,6 +8,6 @@ import softeer.be33ma3.domain.PostPerCenter;
 import java.util.List;
 
 public interface PostPerCenterRepository extends JpaRepository<PostPerCenter, Long> {
-    @Query("SELECT ppc.post FROM PostPerCenter ppc WHERE ppc.center.centerId = :centerId")
-    List<Post> findPostsByCenter_CenterId(Long centerId);
+    @Query("SELECT ppc.post FROM PostPerCenter ppc WHERE ppc.center.centerId = :centerId ORDER BY ppc.post.createTime DESC")
+    List<Post> findPostsByCenter_CenterIdOrderByCreateTimeDesc(Long centerId);
 }

--- a/33ma3/src/main/java/softeer/be33ma3/repository/PostRepository.java
+++ b/33ma3/src/main/java/softeer/be33ma3/repository/PostRepository.java
@@ -7,4 +7,5 @@ import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findByDoneFalse();
+    List<Post> findAllByOrderByCreateTimeDesc();
 }

--- a/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
@@ -35,24 +35,22 @@ public class PostService {
     public List<PostThumbnailDto> showPosts(Member member) {
         // 1. 로그인하지 않았거나 서비스 센터가 아닌 유저일 경우
         if(member == null || member.getMemberType() == MemberService.CLIENT_TYPE) {
-            List<Post> posts = postRepository.findAll();
+            List<Post> posts = postRepository.findAllByOrderByCreateTimeDesc();
             return fromPostList(posts);
         }
         // 2. 서비스 센터일 경우 -> 센터에 해당하는 게시글만 가져오기
         Center center = centerRepository.findByMember_MemberId(member.getMemberId()).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 센터"));
-        List<Post> posts = postPerCenterRepository.findPostsByCenter_CenterId(center.getCenterId());
+        List<Post> posts = postPerCenterRepository.findPostsByCenter_CenterIdOrderByCreateTimeDesc(center.getCenterId());
         return fromPostList(posts);
     }
 
     // List<Post> -> List<PostThumbnailDto>로 변환
     private List<PostThumbnailDto> fromPostList(List<Post> posts) {
-        List<PostThumbnailDto> postThumbnailDtos = new ArrayList<>(posts.stream()
+        return new ArrayList<>(posts.stream()
                 .map(post -> {
                     int offerCount = countOfferNum(post.getPostId());
                     return PostThumbnailDto.fromEntity(post, offerCount);
                 }).toList());
-        Collections.sort(postThumbnailDtos);
-        return postThumbnailDtos;
     }
 
     // 해당 게시글에 달린 댓글 개수 반환

--- a/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
@@ -108,6 +108,8 @@ public class PostService {
     public Object showPost(Long postId, Member member) {
         // 1. 게시글 존재 유무 판단
         Post post = postRepository.findById(postId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글"));
+        if(member == null && !post.isDone())
+            throw new UnauthorizedException("경매 중인 게시글을 보려면 로그인해주세요.");
         // 2. 게시글 세부 사항 가져오기
         PostDetailDto postDetailDto = PostDetailDto.fromEntity(post);
         // 3. 경매가 완료되었거나 글 작성자의 접근일 경우


### PR DESCRIPTION
## 구현 내용
- [x] 경매 진행 중인 게시글의 세부사항 진입 시, 회원가입된 유저만 웹 소켓 연결이 가능하므로 로그인하지 않은 유저의 접근 요청 시 401 응답 반환
- [x] 게시글 세부사항 응답 데이터 및 게시글 목록에 보여지는 썸네일 응답 데이터에 글 작성자의 member id 필드 추가

## 고민 사항
웹 소켓 연결을 하면 생성되는 웹 소켓 세션을 해당하는 멤버의 아이디를 이용하여 저장하고 관리하므로, 회원가입을 한 유저만 통신이 가능할 것이라는 이야기가 나왔다. 로그인하지 않은 유저의 경우 실시간 업데이트 상황까지는 보지 못하더라도 경매 중인 게시글 화면으로 진입 가능하게 하면 좋을 것 같았지만, 웹소켓 연결 요청을 보내는 프론트 쪽에서 해당 화면 진입 과정에서 무조건 연결 요청을 보내기 때문에 아예 화면 진입을 방지하는 것으로 결정되었다. 
아니면 로그인하지 않은 유저의 웹 소켓 연결 요청은 엔드포인트의 member id를 0으로 보내, 이 경우 웹 소켓 연결만 거부하게끔 로직을 짜고 화면은 반환하면 되지 않을까? 생각도 했지만 애초에 우리 서비스의 재미 요소가 실시간 경매이기 때문에, 로그인을 해야만 경매 현황을 볼 수 있도록 한다면 오히려 그게 더 사용자를 늘릴 수 있도록 하는 포인트가 될 수 있을 것 같다. 

## 기타
