### PR TITLE
다중 조건을 이용한 게시글 필터링 기능 구현 #102

### DIFF
--- a/33ma3/.gitignore
+++ b/33ma3/.gitignore
@@ -37,4 +37,5 @@ out/
 .vscode/
 application.yml
 
+### queryDSL QClass ###
 **/generated

--- a/33ma3/.gitignore
+++ b/33ma3/.gitignore
@@ -36,3 +36,5 @@ out/
 ### VS Code ###
 .vscode/
 application.yml
+
+**/generated

--- a/33ma3/build.gradle
+++ b/33ma3/build.gradle
@@ -53,8 +53,32 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	//querydsl
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+// querydsl 설정부
+def generated = 'src/main/generated'
+
+// querydsl QClass 파일 생성 위치를 지정
+tasks.withType(JavaCompile) {
+	options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+// java source set 에 querydsl QClass 위치 추가
+sourceSets {
+	main.java.srcDirs += [ generated ]
+}
+
+// gradle clean 시에 QClass 디렉토리 삭제
+clean {
+	delete file(generated)
 }

--- a/33ma3/src/main/java/softeer/be33ma3/config/QueryDSLConfig.java
+++ b/33ma3/src/main/java/softeer/be33ma3/config/QueryDSLConfig.java
@@ -1,0 +1,18 @@
+package softeer.be33ma3.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDSLConfig {
+    private final EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/33ma3/src/main/java/softeer/be33ma3/controller/OfferController.java
+++ b/33ma3/src/main/java/softeer/be33ma3/controller/OfferController.java
@@ -45,7 +45,7 @@ public class OfferController {
     }
 
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "입찰 성공", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
+            @ApiResponse(responseCode = "200", description = "입찰 성공", content = @Content(schema = @Schema(implementation = DataResponse.class))),
             @ApiResponse(responseCode = "400", description = "존재하지 않는 게시글" + "<br>완료된 게시글" + "<br>존재하지 않는 센터",
                     content = @Content(schema = @Schema(implementation = SingleResponse.class)))
     })
@@ -55,13 +55,13 @@ public class OfferController {
     public ResponseEntity<?> createOffer(@PathVariable("post_id") Long postId,
                                          @RequestBody @Valid OfferCreateDto offerCreateDto,
                                          @Schema(hidden = true) @CurrentUser Member member) {
-        offerService.createOffer(postId, offerCreateDto, member);
+        Long offerId = offerService.createOffer(postId, offerCreateDto, member);
         offerService.sendAboutOfferUpdate(postId);
-        return ResponseEntity.ok(SingleResponse.success("입찰 성공"));
+        return ResponseEntity.ok(DataResponse.success("입찰 성공", offerId));
     }
 
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "댓글 수정 성공", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
+            @ApiResponse(responseCode = "200", description = "댓글 수정 성공", content = @Content(schema = @Schema(implementation = DataResponse.class))),
             @ApiResponse(responseCode = "401", description = "작성자만 수정 가능합니다.",
                     content = @Content(schema = @Schema(implementation = SingleResponse.class))),
             @ApiResponse(responseCode = "400", description = "기존 금액보다 낮은 금액으로만 수정 가능합니다."
@@ -78,11 +78,11 @@ public class OfferController {
                                          @Schema(hidden = true) @CurrentUser Member member) {
         offerService.updateOffer(postId, offerId, offerCreateDto, member);
         offerService.sendAboutOfferUpdate(postId);
-        return ResponseEntity.ok(SingleResponse.success("댓글 수정 성공"));
+        return ResponseEntity.ok(DataResponse.success("댓글 수정 성공", offerId));
     }
 
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "댓글 삭제 성공", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
+            @ApiResponse(responseCode = "200", description = "댓글 삭제 성공", content = @Content(schema = @Schema(implementation = DataResponse.class))),
             @ApiResponse(responseCode = "401", description = "작성자만 삭제 가능합니다.",
                     content = @Content(schema = @Schema(implementation = SingleResponse.class))),
             @ApiResponse(responseCode = "400", description = "존재하지 않는 게시글" + "<br>완료된 게시글" + "<br>존재하지 않는 견적" + "<br>존재하지 않는 센터",
@@ -97,7 +97,7 @@ public class OfferController {
                                          @Schema(hidden = true) @CurrentUser Member member) {
         offerService.deleteOffer(postId, offerId, member);
         offerService.sendAboutOfferUpdate(postId);
-        return ResponseEntity.ok(SingleResponse.success("댓글 삭제 성공"));
+        return ResponseEntity.ok(DataResponse.success("댓글 삭제 성공", offerId));
     }
 
     @ApiResponses({

--- a/33ma3/src/main/java/softeer/be33ma3/controller/PostController.java
+++ b/33ma3/src/main/java/softeer/be33ma3/controller/PostController.java
@@ -46,7 +46,7 @@ public class PostController {
                                        @RequestParam(name = "repair", required = false) String repair,
                                        @RequestParam(name = "tuneUp", required = false) String tuneUp,
                                        @Schema(hidden = true) @CurrentUser Member member) {
-        List<PostThumbnailDto> postThumbnailDtos = postService.showPosts(member);
+        List<PostThumbnailDto> postThumbnailDtos = postService.showPosts(done, region, repair, tuneUp, member);
         return ResponseEntity.ok().body(DataResponse.success("게시글 목록 조회 성공", postThumbnailDtos));
     }
 

--- a/33ma3/src/main/java/softeer/be33ma3/controller/PostController.java
+++ b/33ma3/src/main/java/softeer/be33ma3/controller/PostController.java
@@ -41,7 +41,11 @@ public class PostController {
     })
     @Operation(summary = "게시글 목록 조회", description = "게시글 목록 조회 메서드 입니다.")
     @GetMapping
-    public ResponseEntity<?> showPosts(@Schema(hidden = true) @CurrentUser Member member) {
+    public ResponseEntity<?> showPosts(@RequestParam(name = "done", required = false) Boolean done,
+                                       @RequestParam(name = "region", required = false) String region,
+                                       @RequestParam(name = "repair", required = false) String repair,
+                                       @RequestParam(name = "tuneUp", required = false) String tuneUp,
+                                       @Schema(hidden = true) @CurrentUser Member member) {
         List<PostThumbnailDto> postThumbnailDtos = postService.showPosts(member);
         return ResponseEntity.ok().body(DataResponse.success("게시글 목록 조회 성공", postThumbnailDtos));
     }

--- a/33ma3/src/main/java/softeer/be33ma3/dto/response/PostDetailDto.java
+++ b/33ma3/src/main/java/softeer/be33ma3/dto/response/PostDetailDto.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import softeer.be33ma3.domain.Image;
 import softeer.be33ma3.domain.Post;
+import softeer.be33ma3.service.PostService;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -51,8 +52,8 @@ public class PostDetailDto {
 
     // Post Entity -> PostDetailDto 변환
     public static PostDetailDto fromEntity(Post post) {
-        List<String> repairList = stringCommaParsing(post.getRepairService());
-        List<String> tuneUpList = stringCommaParsing(post.getTuneUpService());
+        List<String> repairList = PostService.stringCommaParsing(post.getRepairService());
+        List<String> tuneUpList = PostService.stringCommaParsing(post.getTuneUpService());
         List<String> imageList = post.getImages().stream().map(Image::getLink).toList();
         Duration duration = calculateDuration(post);
         int dDay = -1;
@@ -74,15 +75,6 @@ public class PostDetailDto {
                 .repairList(repairList)
                 .tuneUpList(tuneUpList)
                 .imageList(imageList).build();
-    }
-
-    // 구분자 콤마로 문자열 파싱 후 각각의 토큰에서 공백 제거 후 리스트 반환
-    public static List<String> stringCommaParsing(String inputString) {
-        if(inputString.isEmpty())
-            return List.of();
-        return Arrays.stream(inputString.split(","))
-                .map(String::strip)
-                .toList();
     }
 
     public static Duration calculateDuration(Post post) {

--- a/33ma3/src/main/java/softeer/be33ma3/dto/response/PostDetailDto.java
+++ b/33ma3/src/main/java/softeer/be33ma3/dto/response/PostDetailDto.java
@@ -51,9 +51,7 @@ public class PostDetailDto {
     private List<String> imageList;
 
     // Post Entity -> PostDetailDto 변환
-    public static PostDetailDto fromEntity(Post post) {
-        List<String> repairList = PostService.stringCommaParsing(post.getRepairService());
-        List<String> tuneUpList = PostService.stringCommaParsing(post.getTuneUpService());
+    public static PostDetailDto fromEntity(Post post, List<String> repairList, List<String> tuneUpList) {
         List<String> imageList = post.getImages().stream().map(Image::getLink).toList();
         Duration duration = calculateDuration(post);
         int dDay = -1;

--- a/33ma3/src/main/java/softeer/be33ma3/dto/response/PostThumbnailDto.java
+++ b/33ma3/src/main/java/softeer/be33ma3/dto/response/PostThumbnailDto.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import softeer.be33ma3.domain.Image;
 import softeer.be33ma3.domain.Post;
+import softeer.be33ma3.service.PostService;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -48,8 +49,8 @@ public class PostThumbnailDto {
     // Post Entity -> PostThumbnailDto 변환
     public static PostThumbnailDto fromEntity(Post post, int offerCount) {
         List<String> imageList = post.getImages().stream().map(Image::getLink).toList();
-        List<String> repairList = PostDetailDto.stringCommaParsing(post.getRepairService());
-        List<String> tuneUpList = PostDetailDto.stringCommaParsing(post.getTuneUpService());
+        List<String> repairList = PostService.stringCommaParsing(post.getRepairService());
+        List<String> tuneUpList = PostService.stringCommaParsing(post.getTuneUpService());
         Duration duration = PostDetailDto.calculateDuration(post);
         int dDay = -1;
         int remainTime = 0;

--- a/33ma3/src/main/java/softeer/be33ma3/dto/response/PostThumbnailDto.java
+++ b/33ma3/src/main/java/softeer/be33ma3/dto/response/PostThumbnailDto.java
@@ -47,10 +47,8 @@ public class PostThumbnailDto {
     private int offerCount;
 
     // Post Entity -> PostThumbnailDto 변환
-    public static PostThumbnailDto fromEntity(Post post, int offerCount) {
+    public static PostThumbnailDto fromEntity(Post post, List<String> repairList, List<String> tuneUpList, int offerCount) {
         List<String> imageList = post.getImages().stream().map(Image::getLink).toList();
-        List<String> repairList = PostService.stringCommaParsing(post.getRepairService());
-        List<String> tuneUpList = PostService.stringCommaParsing(post.getTuneUpService());
         Duration duration = PostDetailDto.calculateDuration(post);
         int dDay = -1;
         int remainTime = 0;

--- a/33ma3/src/main/java/softeer/be33ma3/repository/PostCustomRepository.java
+++ b/33ma3/src/main/java/softeer/be33ma3/repository/PostCustomRepository.java
@@ -1,0 +1,10 @@
+package softeer.be33ma3.repository;
+
+import softeer.be33ma3.domain.Post;
+
+import java.util.List;
+
+public interface PostCustomRepository {
+
+    List<Post> findAllByConditions(Boolean done, List<String> regions, List<String> repairs, List<String> tuneUps, List<Long> postIds);
+}

--- a/33ma3/src/main/java/softeer/be33ma3/repository/PostCustomRepositoryImpl.java
+++ b/33ma3/src/main/java/softeer/be33ma3/repository/PostCustomRepositoryImpl.java
@@ -1,0 +1,12 @@
+package softeer.be33ma3.repository;
+
+import softeer.be33ma3.domain.Post;
+
+import java.util.List;
+
+public class PostCustomRepositoryImpl implements PostCustomRepository {
+    @Override
+    public List<Post> findAllByConditions(Boolean done, List<String> regions, List<String> repairs, List<String> tuneUps, List<Long> postIds) {
+        return null;
+    }
+}

--- a/33ma3/src/main/java/softeer/be33ma3/repository/PostCustomRepositoryImpl.java
+++ b/33ma3/src/main/java/softeer/be33ma3/repository/PostCustomRepositoryImpl.java
@@ -1,12 +1,61 @@
 package softeer.be33ma3.repository;
 
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
 import softeer.be33ma3.domain.Post;
+import static softeer.be33ma3.domain.QPost.post;
 
 import java.util.List;
 
+@Repository
+@RequiredArgsConstructor
 public class PostCustomRepositoryImpl implements PostCustomRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
     @Override
     public List<Post> findAllByConditions(Boolean done, List<String> regions, List<String> repairs, List<String> tuneUps, List<Long> postIds) {
-        return null;
+        BooleanExpression predicate = makeCondition(done, regions, repairs, tuneUps, postIds);
+        return jpaQueryFactory.selectFrom(post)
+                .where(predicate)
+                .fetch();
+    }
+
+    private BooleanExpression makeCondition(Boolean done, List<String> regions, List<String> repairs, List<String> tuneUps, List<Long> postIds) {
+        BooleanExpression predicate = Expressions.TRUE;
+        if(done != null) {
+            predicate = post.done.eq(done);
+        }
+        if(!regions.isEmpty()) {
+            predicate = predicate.and(post.region.regionName.in(regions));
+        }
+        if(!repairs.isEmpty()) {
+            predicate = predicate.and(containsAllService("repair", repairs));
+        }
+        if(!tuneUps.isEmpty()) {
+            predicate = predicate.and(containsAllService("tuneUp", tuneUps));
+        }
+        if(postIds != null) {
+            predicate = predicate.and(post.postId.in(postIds));
+        }
+        return predicate;
+    }
+
+    private BooleanExpression containsAllService(String type, List<String> services) {
+        BooleanExpression expression = Expressions.TRUE;
+        if(type.equals("repair")) {
+            for(String service : services) {
+                expression = expression.and(post.repairService.contains(service));
+            }
+        }
+        else if(type.equals("tuneUp")) {
+            for(String service : services) {
+                expression = expression.and(post.tuneUpService.contains(service));
+            }
+        }
+        return expression;
     }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/repository/PostCustomRepositoryImpl.java
+++ b/33ma3/src/main/java/softeer/be33ma3/repository/PostCustomRepositoryImpl.java
@@ -21,6 +21,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
         BooleanExpression predicate = makeCondition(done, regions, repairs, tuneUps, postIds);
         return jpaQueryFactory.selectFrom(post)
                 .where(predicate)
+                .orderBy(post.createTime.desc(), post.postId.desc())
                 .fetch();
     }
 

--- a/33ma3/src/main/java/softeer/be33ma3/repository/PostCustomRepositoryImpl.java
+++ b/33ma3/src/main/java/softeer/be33ma3/repository/PostCustomRepositoryImpl.java
@@ -45,17 +45,9 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
     }
 
     private BooleanExpression containsAllService(String type, List<String> services) {
-        BooleanExpression expression = Expressions.TRUE;
-        if(type.equals("repair")) {
-            for(String service : services) {
-                expression = expression.and(post.repairService.contains(service));
-            }
-        }
-        else if(type.equals("tuneUp")) {
-            for(String service : services) {
-                expression = expression.and(post.tuneUpService.contains(service));
-            }
-        }
-        return expression;
+        return services.stream()
+                .map(service -> type.equals("repair") ? post.repairService.contains(service) : post.tuneUpService.contains(service))
+                .reduce(BooleanExpression::and)
+                .orElse(Expressions.TRUE);
     }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/repository/PostPerCenterRepository.java
+++ b/33ma3/src/main/java/softeer/be33ma3/repository/PostPerCenterRepository.java
@@ -8,8 +8,6 @@ import softeer.be33ma3.domain.PostPerCenter;
 import java.util.List;
 
 public interface PostPerCenterRepository extends JpaRepository<PostPerCenter, Long> {
-    @Query("SELECT ppc.post FROM PostPerCenter ppc WHERE ppc.center.centerId = :centerId ORDER BY ppc.post.createTime DESC")
-    List<Post> findPostsByCenterIdOrderByCreateTimeDesc(Long centerId);
 
     @Query("SELECT ppc.post.postId FROM PostPerCenter ppc WHERE ppc.center.centerId = :centerId")
     List<Long> findPostIdsByCenterId(Long centerId);

--- a/33ma3/src/main/java/softeer/be33ma3/repository/PostPerCenterRepository.java
+++ b/33ma3/src/main/java/softeer/be33ma3/repository/PostPerCenterRepository.java
@@ -9,5 +9,8 @@ import java.util.List;
 
 public interface PostPerCenterRepository extends JpaRepository<PostPerCenter, Long> {
     @Query("SELECT ppc.post FROM PostPerCenter ppc WHERE ppc.center.centerId = :centerId ORDER BY ppc.post.createTime DESC")
-    List<Post> findPostsByCenter_CenterIdOrderByCreateTimeDesc(Long centerId);
+    List<Post> findPostsByCenterIdOrderByCreateTimeDesc(Long centerId);
+
+    @Query("SELECT ppc.post.postId FROM PostPerCenter ppc WHERE ppc.center.centerId = :centerId")
+    List<Long> findPostIdsByCenterId(Long centerId);
 }

--- a/33ma3/src/main/java/softeer/be33ma3/repository/PostRepository.java
+++ b/33ma3/src/main/java/softeer/be33ma3/repository/PostRepository.java
@@ -7,5 +7,4 @@ import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post, Long>, PostCustomRepository {
     List<Post> findByDoneFalse();
-    List<Post> findAllByOrderByCreateTimeDesc();
 }

--- a/33ma3/src/main/java/softeer/be33ma3/repository/PostRepository.java
+++ b/33ma3/src/main/java/softeer/be33ma3/repository/PostRepository.java
@@ -5,7 +5,7 @@ import softeer.be33ma3.domain.Post;
 
 import java.util.List;
 
-public interface PostRepository extends JpaRepository<Post, Long> {
+public interface PostRepository extends JpaRepository<Post, Long>, PostCustomRepository {
     List<Post> findByDoneFalse();
     List<Post> findAllByOrderByCreateTimeDesc();
 }

--- a/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
@@ -1,6 +1,7 @@
 package softeer.be33ma3.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import softeer.be33ma3.dto.response.AvgPriceDto;
@@ -25,6 +26,7 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
+@Slf4j
 public class OfferService {
 
     private final OfferRepository offerRepository;
@@ -105,7 +107,7 @@ public class OfferService {
         // 5. 댓글 낙찰, 게시글 마감 처리
         offer.setSelected();
         post.setDone();
-        // 6. 서비스 센터들에게 낙찰 또는 경매 마감 메세지 보내기
+        // TODO: 6. 서비스 센터들에게 낙찰 또는 경매 마감 메세지 보내기
         Long selectedMemberId = offer.getCenter().getMember().getMemberId();
         sendMessageAfterSelection(postId, selectedMemberId);
         webSocketHandler.deletePostRoom(postId);
@@ -153,8 +155,11 @@ public class OfferService {
         // 1. 게시글에 속해있는 댓글 목록 가져오기
         List<Offer> offerList = offerRepository.findByPost_PostId(postId);
         List<OfferDetailDto> offerDetailList = OfferDetailDto.fromEntityList(offerList);
-        // 1. 전송하기
-        webSocketHandler.sendData2Client(memberId, offerDetailList);
+        // 2. 해당 게시글 화면에 진입해 있을 경우 전송하기
+        if(webSocketHandler.isInPostRoom(postId, memberId)) {
+            log.info("게시글 작성자에게 실시간 댓글 전송 진행");
+            webSocketHandler.sendData2Client(memberId, offerDetailList);
+        }
     }
 
     // 해당 게시글 화면을 보고 있는 모든 유저들에게 평균 견적 제시 가격 실시간 전송
@@ -163,6 +168,10 @@ public class OfferService {
         List<Offer> offerList = offerRepository.findByPost_PostId(postId);
         // 2. 해당 게시글을 보고 있는 모든 유저들 가져오기 (글 작성자도 포함되어있을 경우 제외시키기)
         Set<Long> memberList = webSocketHandler.findAllMemberInPost(postId);
+        if(memberList == null) {
+            log.info("해당 게시글을 보고 있는 유저가 없습니다.");
+            return;
+        }
         memberList = memberList.stream()
                 .filter(memberId -> !memberId.equals(writerId))
                 .collect(Collectors.toSet());

--- a/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
@@ -45,7 +45,7 @@ public class OfferService {
 
     // 견적 제시 댓글 생성
     @Transactional
-    public void createOffer(Long postId, OfferCreateDto offerCreateDto, Member member) {
+    public Long createOffer(Long postId, OfferCreateDto offerCreateDto, Member member) {
         // 1. 해당 게시글이 마감 전인지 확인
         Post post = checkNotDonePost(postId);
         // 2. 센터 정보 가져오기
@@ -55,7 +55,8 @@ public class OfferService {
                 .ifPresent(offer -> {throw new UnauthorizedException("이미 견적을 작성하였습니다.");});
         // 4. 댓글 생성하여 저장하기
         Offer offer = offerCreateDto.toEntity(post, center);
-        offerRepository.save(offer);
+        Offer savedOffer = offerRepository.save(offer);
+        return savedOffer.getOfferId();
     }
 
     // 견적 제시 댓글 수정

--- a/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
@@ -49,8 +49,10 @@ public class PostService {
     private List<PostThumbnailDto> fromPostList(List<Post> posts) {
         return new ArrayList<>(posts.stream()
                 .map(post -> {
+                    List<String> repairList = stringCommaParsing(post.getRepairService());
+                    List<String> tuneUpList = stringCommaParsing(post.getTuneUpService());
                     int offerCount = countOfferNum(post.getPostId());
-                    return PostThumbnailDto.fromEntity(post, offerCount);
+                    return PostThumbnailDto.fromEntity(post, repairList, tuneUpList, offerCount);
                 }).toList());
     }
 
@@ -110,7 +112,9 @@ public class PostService {
         if(member == null && !post.isDone())
             throw new UnauthorizedException("경매 중인 게시글을 보려면 로그인해주세요.");
         // 2. 게시글 세부 사항 가져오기
-        PostDetailDto postDetailDto = PostDetailDto.fromEntity(post);
+        List<String> repairList = stringCommaParsing(post.getRepairService());
+        List<String> tuneUpList = stringCommaParsing(post.getTuneUpService());
+        PostDetailDto postDetailDto = PostDetailDto.fromEntity(post, repairList, tuneUpList);
         // 3. 경매가 완료되었거나 글 작성자의 접근일 경우
         if(post.isDone() || (member!=null && post.getMember().equals(member))) {
             List<Offer> offerList = offerRepository.findByPost_PostId(postId);

--- a/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
@@ -33,7 +33,6 @@ public class PostService {
 
     // 게시글 목록 조회
     public List<PostThumbnailDto> showPosts(Boolean done, String region, String repair, String tuneUp, Member member) {
-        System.out.println("here! :" + done + " " + region + " " + repair + " " + tuneUp + " " + member);
         List<String> regions = stringCommaParsing(region);
         List<String> repairs = stringCommaParsing(repair);
         List<String> tuneUps = stringCommaParsing(tuneUp);

--- a/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
@@ -175,4 +175,13 @@ public class PostService {
 
         return post;
     }
+
+    // 구분자 콤마로 문자열 파싱 후 각각의 토큰에서 공백 제거 후 리스트 반환
+    public static List<String> stringCommaParsing(String inputString) {
+        if(inputString.isEmpty())
+            return List.of();
+        return Arrays.stream(inputString.split(","))
+                .map(String::strip)
+                .toList();
+    }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
@@ -32,20 +32,8 @@ public class PostService {
     private final ImageService imageService;
 
     // 게시글 목록 조회
-    public List<PostThumbnailDto> showPosts(Member member) {
-        // 1. 로그인하지 않았거나 서비스 센터가 아닌 유저일 경우
-        if(member == null || member.getMemberType() == MemberService.CLIENT_TYPE) {
-            List<Post> posts = postRepository.findAllByOrderByCreateTimeDesc();
-            return fromPostList(posts);
-        }
-        // 2. 서비스 센터일 경우 -> 센터에 해당하는 게시글만 가져오기
-        Center center = centerRepository.findByMember_MemberId(member.getMemberId()).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 센터"));
-        List<Post> posts = postPerCenterRepository.findPostsByCenterIdOrderByCreateTimeDesc(center.getCenterId());
-        return fromPostList(posts);
-    }
-
-    // 게시글 목록 조회
     public List<PostThumbnailDto> showPosts(Boolean done, String region, String repair, String tuneUp, Member member) {
+        System.out.println("here! :" + done + " " + region + " " + repair + " " + tuneUp + " " + member);
         List<String> regions = stringCommaParsing(region);
         List<String> repairs = stringCommaParsing(repair);
         List<String> tuneUps = stringCommaParsing(tuneUp);
@@ -193,7 +181,7 @@ public class PostService {
 
     // 구분자 콤마로 문자열 파싱 후 각각의 토큰에서 공백 제거 후 리스트 반환
     public static List<String> stringCommaParsing(String inputString) {
-        if(inputString.isBlank())
+        if(inputString == null || inputString.isBlank())
             return List.of();
         return Arrays.stream(inputString.split(","))
                 .map(String::strip)

--- a/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
@@ -40,7 +40,22 @@ public class PostService {
         }
         // 2. 서비스 센터일 경우 -> 센터에 해당하는 게시글만 가져오기
         Center center = centerRepository.findByMember_MemberId(member.getMemberId()).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 센터"));
-        List<Post> posts = postPerCenterRepository.findPostsByCenter_CenterIdOrderByCreateTimeDesc(center.getCenterId());
+        List<Post> posts = postPerCenterRepository.findPostsByCenterIdOrderByCreateTimeDesc(center.getCenterId());
+        return fromPostList(posts);
+    }
+
+    // 게시글 목록 조회
+    public List<PostThumbnailDto> showPosts(Boolean done, String region, String repair, String tuneUp, Member member) {
+        List<String> regions = stringCommaParsing(region);
+        List<String> repairs = stringCommaParsing(repair);
+        List<String> tuneUps = stringCommaParsing(tuneUp);
+        List<Post> posts = List.of();
+        List<Long> postIds = null;
+        if(member != null && member.getMemberType() == CENTER_TYPE) {
+            Center center = centerRepository.findByMember_MemberId(member.getMemberId()).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 센터"));
+            postIds = postPerCenterRepository.findPostIdsByCenterId(center.getCenterId());
+        }
+        posts = postRepository.findAllByConditions(done, regions, repairs, tuneUps, postIds);
         return fromPostList(posts);
     }
 
@@ -178,7 +193,7 @@ public class PostService {
 
     // 구분자 콤마로 문자열 파싱 후 각각의 토큰에서 공백 제거 후 리스트 반환
     public static List<String> stringCommaParsing(String inputString) {
-        if(inputString.isEmpty())
+        if(inputString.isBlank())
             return List.of();
         return Arrays.stream(inputString.split(","))
                 .map(String::strip)

--- a/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
@@ -36,13 +36,12 @@ public class PostService {
         List<String> regions = stringCommaParsing(region);
         List<String> repairs = stringCommaParsing(repair);
         List<String> tuneUps = stringCommaParsing(tuneUp);
-        List<Post> posts = List.of();
         List<Long> postIds = null;
         if(member != null && member.getMemberType() == CENTER_TYPE) {
             Center center = centerRepository.findByMember_MemberId(member.getMemberId()).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 센터"));
             postIds = postPerCenterRepository.findPostIdsByCenterId(center.getCenterId());
         }
-        posts = postRepository.findAllByConditions(done, regions, repairs, tuneUps, postIds);
+        List<Post> posts = postRepository.findAllByConditions(done, regions, repairs, tuneUps, postIds);
         return fromPostList(posts);
     }
 

--- a/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketHandler.java
+++ b/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketHandler.java
@@ -72,4 +72,7 @@ public class WebSocketHandler extends TextWebSocketHandler {
     public Set<Long> findAllMemberInPost(Long postId) {
         return webSocketService.findAllMemberInPost(postId);
     }
+    public boolean isInPostRoom(Long postId, Long memberId) {
+        return webSocketService.isInPostRoom(postId, memberId);
+    }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketService.java
@@ -47,6 +47,8 @@ public class WebSocketService {
 
     // 데이터 (클래스 객체) 전송
     public void sendData(Long memberId, Object data) throws IOException {
+        if(memberId == null || data == null)
+            return;
         // 클라이언트에 해당하는 세션 가져오기
         WebSocketSession session = webSocketRepository.findSessionByMemberId(memberId);
         if(session == null) {
@@ -76,5 +78,12 @@ public class WebSocketService {
     // 해당 게시글에 접속해있는 유저 목록 반환
     public Set<Long> findAllMemberInPost(Long postId) {
         return webSocketRepository.findAllMemberInPost(postId);
+    }
+
+    public boolean isInPostRoom(Long postId, Long memberId) {
+        Set<Long> memberIds = webSocketRepository.findAllMemberInPost(postId);
+        if(memberId == null)
+            return false;
+        return memberIds.contains(memberId);
     }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketService.java
@@ -82,7 +82,7 @@ public class WebSocketService {
 
     public boolean isInPostRoom(Long postId, Long memberId) {
         Set<Long> memberIds = webSocketRepository.findAllMemberInPost(postId);
-        if(memberId == null)
+        if(memberIds == null)
             return false;
         return memberIds.contains(memberId);
     }


### PR DESCRIPTION
## 구현 내용
- [x] requestParam으로 다중 조건을 받고 문자열 파싱
- [x] 일반 유저의 경우 상관없으나, 서비스 센터일 경우 해당 센터에 할당되어있는 게시글만 보여주도록 필터링
- [x] queryDSL을 이용

## 고민 사항
선택 조건이 많아질수록 쿼리 스트링 부분이 너무 길어지는 문제가 있었다. 그래서 그냥 Post 요청을 통해 바디로 받을까 했었는데, 기존 게시글 목록 페이지에서 선택한 조건에 부합하는 게시글을 조합해 보여준다는 기능을 생각해봤을 때 Post 요청에 맞지 않다는 생각이 들었다. 그래서 쿼리 스트링이 조금 길어지더라도 requestParam으로 받기로 했고, 대신 지역의 경우 전체 25개의 선택지 중 최대 3개까지만 선택할 수 있도록 하자고 이야기가 되었다. 
그리고 queryDSL을 처음 사용해봤는데, 오 너무 편한 것 같다. queryDSL 사용을 위한 의존성 설정만 조금 조심하면 복잡한 쿼리문을 사용해야될 때 자유롭게 코드를 짜듯이 짤 수 있을 것 같다. 다양한 조건을 이용하고, 또 유저 타입에 따라 반환해야되는 데이터가 달라지는 우리 서비스에서 잘 이용하면 좋을 것 같다.
지난번 queryDSL 의존성을 새로 설정하고 빌드했을 때 자꾸 실패가 떠서 서버 자체도 실행이 안될 거라고 생각했었는데, 알고보니 테스트 코드에서만 빌드 실패가 뜨는거라 서버 실행에는 문제가 없었다. 

## 기타
이번주 금요일 강의실에다 이어폰 두고 왔다. 너무 슬프다. 하필 주말에...