### PR TITLE
채팅 목록 기능 구현 #106

### DIFF
--- a/33ma3/src/main/java/softeer/be33ma3/controller/ChatController.java
+++ b/33ma3/src/main/java/softeer/be33ma3/controller/ChatController.java
@@ -14,6 +14,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import softeer.be33ma3.domain.Member;
 import softeer.be33ma3.dto.request.ChatMessageRequestDto;
+import softeer.be33ma3.dto.response.ChatHistoryDto;
 import softeer.be33ma3.dto.response.ChatRoomListDto;
 import softeer.be33ma3.jwt.CurrentUser;
 import softeer.be33ma3.response.DataResponse;
@@ -67,5 +68,12 @@ public class ChatController {
         List<ChatRoomListDto> allChatRoomListDto = chatService.showAllChatRoom(member);
 
         return ResponseEntity.ok().body(DataResponse.success("문의 내역 전송 성공", allChatRoomListDto));
+    }
+
+    @GetMapping("/chat/history/{roomId}")
+    public ResponseEntity<?> showOneChatHistory(@CurrentUser Member member, @PathVariable("roomId") Long roomId){
+         List<ChatHistoryDto> chatHistoryDtos = chatService.showOneChatHistory(member, roomId);
+
+        return ResponseEntity.ok().body(DataResponse.success("채팅 내역 전송 성공", chatHistoryDtos));
     }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/controller/ChatController.java
+++ b/33ma3/src/main/java/softeer/be33ma3/controller/ChatController.java
@@ -64,14 +64,20 @@ public class ChatController {
     @ApiResponse(responseCode = "200", description = "문의 내역 전송 성공", content = @Content(schema = @Schema(implementation = DataResponse.class)))
     @Operation(summary = "문의 내역", description = "문의 내역 보기 메서드 입니다.")
     @GetMapping("/chatRoom/all")
-    public ResponseEntity<?> showAllChatRoom(@CurrentUser Member member){
+    public ResponseEntity<?> showAllChatRoom(@Schema(hidden = true) @CurrentUser Member member){
         List<ChatRoomListDto> allChatRoomListDto = chatService.showAllChatRoom(member);
 
         return ResponseEntity.ok().body(DataResponse.success("문의 내역 전송 성공", allChatRoomListDto));
     }
 
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "채팅 내역 전송 성공", content = @Content(schema = @Schema(implementation = DataResponse.class))),
+            @ApiResponse(responseCode = "401", description = "해당 방의 회원이 아닙니다.", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
+            @ApiResponse(responseCode = "400", description = "존재하지 않는 채팅 룸", content = @Content(schema = @Schema(implementation = SingleResponse.class)))
+    })
+    @Operation(summary = "채팅 내역 조회", description = "채팅 내역을 조회하는 메서드 입니다.")
     @GetMapping("/chat/history/{roomId}")
-    public ResponseEntity<?> showOneChatHistory(@CurrentUser Member member, @PathVariable("roomId") Long roomId){
+    public ResponseEntity<?> showOneChatHistory(@Schema(hidden = true) @CurrentUser Member member, @PathVariable("roomId") Long roomId){
          List<ChatHistoryDto> chatHistoryDtos = chatService.showOneChatHistory(member, roomId);
 
         return ResponseEntity.ok().body(DataResponse.success("채팅 내역 전송 성공", chatHistoryDtos));

--- a/33ma3/src/main/java/softeer/be33ma3/controller/LocationController.java
+++ b/33ma3/src/main/java/softeer/be33ma3/controller/LocationController.java
@@ -6,7 +6,6 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -27,9 +26,7 @@ import java.util.List;
 public class LocationController {
     private final LocationService locationService;
 
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "모든 센터 정보 전송 완료", content = @Content(schema = @Schema(implementation = DataResponse.class)))
-    })
+    @ApiResponse(responseCode = "200", description = "모든 센터 정보 전송 완료", content = @Content(schema = @Schema(implementation = DataResponse.class)))
     @Operation(summary = "모든 센터 정보", description = "모든 센터 정보를 내려주는 메소드입니다.")
     @GetMapping("/center/all")
     public ResponseEntity<?> getAllCenters(){
@@ -38,9 +35,7 @@ public class LocationController {
         return ResponseEntity.ok().body(DataResponse.success("모든 센터 정보 전송 완료", centers));
     }
 
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "반경 내 위치한 센터 정보 전송 완료", content = @Content(schema = @Schema(implementation = DataResponse.class)))
-    })
+    @ApiResponse(responseCode = "200", description = "반경 내 위치한 센터 정보 전송 완료", content = @Content(schema = @Schema(implementation = DataResponse.class)))
     @Operation(summary = "반경 안 센터 정보", description = "반경안에 있는 센터 정보를 내려주는 메소드입니다.")
     @Parameter(name = "latitude", description = "위도", example = "37.12345", in = ParameterIn.QUERY)
     @Parameter(name = "longitude", description = "경도", example = "127.12345", in = ParameterIn.QUERY)

--- a/33ma3/src/main/java/softeer/be33ma3/dto/response/ChatHistoryDto.java
+++ b/33ma3/src/main/java/softeer/be33ma3/dto/response/ChatHistoryDto.java
@@ -1,0 +1,31 @@
+package softeer.be33ma3.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+import softeer.be33ma3.domain.ChatMessage;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Data
+@Builder
+public class ChatHistoryDto {
+    private Long senderId;
+    private String contents;
+    private String createTime;
+    private boolean readDone;
+
+    public static ChatHistoryDto getChatHistoryDto(ChatMessage chatMessage){
+        return ChatHistoryDto.builder()
+                .senderId(chatMessage.getSender().getMemberId())
+                .contents(chatMessage.getContents())
+                .createTime(createTimeFormatting(chatMessage.getCreateTime()))
+                .readDone(chatMessage.isReadDone())
+                .build();
+    }
+
+    private static String createTimeFormatting(LocalDateTime createTime) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm");
+        return createTime.format(formatter);
+    }
+}

--- a/33ma3/src/main/java/softeer/be33ma3/dto/response/ChatHistoryDto.java
+++ b/33ma3/src/main/java/softeer/be33ma3/dto/response/ChatHistoryDto.java
@@ -16,7 +16,7 @@ public class ChatHistoryDto {
     private Long senderId;
     @Schema(description = "메세지 내용", example = "안녕하세요")
     private String contents;
-    @Schema(description = "메세지 생성 시간", example = "07:12")
+    @Schema(description = "메세지 생성 시간", example = "오전 07:12")
     private String createTime;
     @Schema(description = "읽음 여부", example = "1")
     private boolean readDone;

--- a/33ma3/src/main/java/softeer/be33ma3/dto/response/ChatHistoryDto.java
+++ b/33ma3/src/main/java/softeer/be33ma3/dto/response/ChatHistoryDto.java
@@ -1,5 +1,6 @@
 package softeer.be33ma3.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
 import softeer.be33ma3.domain.ChatMessage;
@@ -9,10 +10,15 @@ import java.time.format.DateTimeFormatter;
 
 @Data
 @Builder
+@Schema(description = "채팅 내역")
 public class ChatHistoryDto {
+    @Schema(description = "보내는 사람 아이디", example = "1")
     private Long senderId;
+    @Schema(description = "메세지 내용", example = "안녕하세요")
     private String contents;
+    @Schema(description = "메세지 생성 시간", example = "07:12")
     private String createTime;
+    @Schema(description = "읽음 여부", example = "1")
     private boolean readDone;
 
     public static ChatHistoryDto getChatHistoryDto(ChatMessage chatMessage){

--- a/33ma3/src/main/java/softeer/be33ma3/dto/response/ChatHistoryDto.java
+++ b/33ma3/src/main/java/softeer/be33ma3/dto/response/ChatHistoryDto.java
@@ -31,7 +31,9 @@ public class ChatHistoryDto {
     }
 
     private static String createTimeFormatting(LocalDateTime createTime) {
+        String periodOfDay = createTime.getHour() < 12 ? "오전 " : "오후 ";
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm");
-        return createTime.format(formatter);
+
+        return periodOfDay + createTime.format(formatter);
     }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/jwt/JwtProperties.java
+++ b/33ma3/src/main/java/softeer/be33ma3/jwt/JwtProperties.java
@@ -1,7 +1,7 @@
 package softeer.be33ma3.jwt;
 
 public interface JwtProperties {
-    long ACCESS_TOKEN_TIME = 1000 * 60 * 33; //33분
+    long ACCESS_TOKEN_TIME = 1000 * 60 * 333; //33분
     long REFRESH_TOKEN_TIME = 1000 * 60 * 60 * 24 * 13;  //13일
     String ACCESS_PREFIX_STRING = "Bearer ";
     String ACCESS_HEADER_STRING = "Authorization";

--- a/33ma3/src/main/java/softeer/be33ma3/service/ChatService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/ChatService.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import softeer.be33ma3.domain.*;
+import softeer.be33ma3.dto.response.ChatHistoryDto;
 import softeer.be33ma3.dto.response.ChatRoomListDto;
 import softeer.be33ma3.dto.response.ChatMessageResponseDto;
 import softeer.be33ma3.exception.UnauthorizedException;
@@ -92,6 +93,29 @@ public class ChatService {
         }
 
         return allChatRoomListDto;
+    }
+
+    public List<ChatHistoryDto> showOneChatHistory(Member member, Long roomId) {
+        ChatRoom chatRoom = chatRoomRepository.findById(roomId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 채팅 룸"));
+        validateMember(member, chatRoom);
+
+        List<ChatMessage> chatMessages = chatMessageRepository.findByChatRoom_ChatRoomId(chatRoom.getChatRoomId());
+        //TODO: 읽음 처리 하기
+        return chatMessages.stream()
+                .map(ChatHistoryDto::getChatHistoryDto)
+                .toList();
+    }
+
+    private static void validateMember(Member member, ChatRoom chatRoom) {
+        if(member.getMemberType() == CLIENT_TYPE){      //클라이언트인 경우
+            if(!chatRoom.getClient().equals(member)) {       //방에 있는 클라이언트와 내역을 확인하려는 클라이언트가 같은지 확인
+                throw new UnauthorizedException("해당 방의 회원이 아닙니다.");
+            }
+        }
+        //센터인 경우
+        if(!chatRoom.getCenter().equals(member)){       //방에 있는 센터와 내역을 확인하려는 센터가 같은지 확인
+            throw new IllegalArgumentException("해당 방의 회원이 아닙니다.");
+        }
     }
 
     private ChatRoomListDto getChatDto(ChatRoom chatRoom, String memberName, Member member) {

--- a/33ma3/src/main/java/softeer/be33ma3/service/ChatService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/ChatService.java
@@ -119,7 +119,7 @@ public class ChatService {
         }
 
         if (member.getMemberType() == CENTER_TYPE && !chatRoom.getCenter().equals(member)) {
-            throw new IllegalArgumentException("해당 방의 회원이 아닙니다.");
+            throw new UnauthorizedException("해당 방의 회원이 아닙니다.");
         }
     }
 

--- a/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
@@ -83,7 +83,6 @@ public class PostService {
         return savedPost.getPostId();
     }
 
-
     @Transactional
     public void editPost(Member member, Long postId, PostCreateDto postCreateDto) {
         Post post = validPostAndMember(member, postId);
@@ -91,6 +90,7 @@ public class PostService {
         Region region = getRegion(postCreateDto.getLocation());
         post.editPost(postCreateDto, region);
     }
+
     @Transactional
     public void deletePost(Member member, Long postId) {
         Post post = validPostAndMember(member, postId);


### PR DESCRIPTION
## 구현 내용
- [x] 채팅 방 선택시 기존에 했던 내용들을 내려주는 기능 구현
- [x] 예외처리
-해당 방의 멤버가 아닌 경우 예외처리
- [x] 메세지 읽음 처리
- 메세지 기록 중에 읽지 않은 메세지의 경우 채팅 내역 조회시 읽음으로 처리
- [ ] 실시간으로 목록이 업데이트 되도록 구현하기

## 고민 사항

## 기타
이제 리팩토링을 먼저 해야겠다....