### PR TITLE
에러 상태 메세지 이넘으로 관리하도록 수정 #125

### DIFF
--- a/33ma3/src/main/java/softeer/be33ma3/controller/ChatController.java
+++ b/33ma3/src/main/java/softeer/be33ma3/controller/ChatController.java
@@ -32,7 +32,7 @@ public class ChatController {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "채팅방 생성 성공", content = @Content(schema = @Schema(implementation = DataResponse.class))),
             @ApiResponse(responseCode = "401", description = "게시글 작성자만 생성할 수 있습니다.", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
-            @ApiResponse(responseCode = "400", description = "존재하지 않는 게시글" + "<br>존재하지 않는 센터", content = @Content(schema = @Schema(implementation = SingleResponse.class)))
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 게시글" + "<br>존재하지 않는 센터", content = @Content(schema = @Schema(implementation = SingleResponse.class)))
     })
     @Parameter(name = "post_id", description = "게시글 id", required = true, example = "1", in = ParameterIn.PATH)
     @Parameter(name = "center_id", description = "문의할 센터 id", required = true, example = "2", in = ParameterIn.PATH)
@@ -47,7 +47,7 @@ public class ChatController {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "메세지 전송 성공", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
             @ApiResponse(responseCode = "401", description = "해당 방의 회원이 아닙니다.", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
-            @ApiResponse(responseCode = "400", description = "존재하지 않는 회원" + "<br>존재하지 않는 채팅 룸", content = @Content(schema = @Schema(implementation = SingleResponse.class)))
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 회원" + "<br>존재하지 않는 채팅 룸", content = @Content(schema = @Schema(implementation = SingleResponse.class)))
     })
     @Parameter(name = "room_id", description = "채팅방 id", required = true, example = "1", in = ParameterIn.PATH)
     @Parameter(name = "receiver_id", description = "메세지 받는 사람 id", required = true, example = "2", in = ParameterIn.PATH)

--- a/33ma3/src/main/java/softeer/be33ma3/controller/MemberController.java
+++ b/33ma3/src/main/java/softeer/be33ma3/controller/MemberController.java
@@ -31,7 +31,7 @@ public class MemberController {
 
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "회원가입 성공", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
-            @ApiResponse(responseCode = "400", description = "이미 존재하는 아이디" + "<br>올바르지 않은 memberType", content = @Content(schema = @Schema(implementation = SingleResponse.class)))
+            @ApiResponse(responseCode = "400", description = "이미 존재하는 아이디", content = @Content(schema = @Schema(implementation = SingleResponse.class)))
     })
     @Operation(summary = "일반 사용자 회원가입", description = "사용자 회원가입 메서드 입니다.")
     @PostMapping("/client/signUp")
@@ -43,7 +43,7 @@ public class MemberController {
 
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "회원가입 성공", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
-            @ApiResponse(responseCode = "400", description = "이미 존재하는 아이디" + "<br>올바르지 않은 memberType", content = @Content(schema = @Schema(implementation = SingleResponse.class)))
+            @ApiResponse(responseCode = "400", description = "이미 존재하는 아이디", content = @Content(schema = @Schema(implementation = SingleResponse.class)))
     })
     @Operation(summary = "센터 회원가입", description = "센터 회원가입 메서드 입니다.")
     @PostMapping("/center/signUp")
@@ -67,7 +67,7 @@ public class MemberController {
 
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "토큰 재발급 성공", content = @Content(schema = @Schema(implementation = DataResponse.class))),
-            @ApiResponse(responseCode = "400", description = "존재하지 않는 회원", content = @Content(schema = @Schema(implementation = SingleResponse.class)))
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 회원", content = @Content(schema = @Schema(implementation = SingleResponse.class)))
     })
     @Operation(summary = "엑세스 토큰 재발급", description = "엑세스 토큰 재발급 메서드 입니다.")
     @PostMapping("/reissueToken")   //refreshToken 으로 accessToken 재발급

--- a/33ma3/src/main/java/softeer/be33ma3/controller/OfferController.java
+++ b/33ma3/src/main/java/softeer/be33ma3/controller/OfferController.java
@@ -31,8 +31,7 @@ public class OfferController {
 
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "견적 불러오기 성공", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
-            @ApiResponse(responseCode = "400", description = "존재하지 않는 게시글" + "<br>존재하지 않는 견적",
-                    content = @Content(schema = @Schema(implementation = SingleResponse.class)))
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 게시글" + "<br>존재하지 않는 견적", content = @Content(schema = @Schema(implementation = SingleResponse.class)))
     })
     @Parameter(name = "post_id", description = "게시글 id", required = true, example = "1", in = ParameterIn.PATH)
     @Parameter(name = "offer_id", description = "offer id", required = true, example = "2", in = ParameterIn.PATH)
@@ -46,8 +45,8 @@ public class OfferController {
 
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "입찰 성공", content = @Content(schema = @Schema(implementation = DataResponse.class))),
-            @ApiResponse(responseCode = "400", description = "존재하지 않는 게시글" + "<br>완료된 게시글" + "<br>존재하지 않는 센터",
-                    content = @Content(schema = @Schema(implementation = SingleResponse.class)))
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 게시글" + "<br>존재하지 않는 센터", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
+            @ApiResponse(responseCode = "400", description = "완료된 게시글", content = @Content(schema = @Schema(implementation = SingleResponse.class)))
     })
     @Parameter(name = "post_id", description = "입찰할 게시글 id", required = true, example = "1", in = ParameterIn.PATH)
     @Operation(summary = "입찰 하기", description = "입찰하기 메서드 입니다.")
@@ -62,11 +61,9 @@ public class OfferController {
 
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "댓글 수정 성공", content = @Content(schema = @Schema(implementation = DataResponse.class))),
-            @ApiResponse(responseCode = "401", description = "작성자만 수정 가능합니다.",
-                    content = @Content(schema = @Schema(implementation = SingleResponse.class))),
-            @ApiResponse(responseCode = "400", description = "기존 금액보다 낮은 금액으로만 수정 가능합니다."
-                    + "<br>존재하지 않는 게시글" + "<br>완료된 게시글" + "<br>존재하지 않는 견적" + "<br>존재하지 않는 센터",
-                    content = @Content(schema = @Schema(implementation = SingleResponse.class)))
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 게시글" + "<br>존재하지 않는 센터" + "<br>존재하지 않는 견적", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
+            @ApiResponse(responseCode = "401", description = "작성자만 가능합니다.", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
+            @ApiResponse(responseCode = "400", description = "기존 금액보다 낮은 금액으로만 수정 가능합니다."  + "<br>완료된 게시글", content = @Content(schema = @Schema(implementation = SingleResponse.class)))
     })
     @Parameter(name = "post_id", description = "게시글 id", required = true, example = "1", in = ParameterIn.PATH)
     @Parameter(name = "offer_id", description = "offer id", required = true, example = "2", in = ParameterIn.PATH)
@@ -83,10 +80,9 @@ public class OfferController {
 
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "댓글 삭제 성공", content = @Content(schema = @Schema(implementation = DataResponse.class))),
-            @ApiResponse(responseCode = "401", description = "작성자만 삭제 가능합니다.",
-                    content = @Content(schema = @Schema(implementation = SingleResponse.class))),
-            @ApiResponse(responseCode = "400", description = "존재하지 않는 게시글" + "<br>완료된 게시글" + "<br>존재하지 않는 견적" + "<br>존재하지 않는 센터",
-                    content = @Content(schema = @Schema(implementation = SingleResponse.class)))
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 게시글" + "<br>존재하지 않는 센터" + "<br>존재하지 않는 견적", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
+            @ApiResponse(responseCode = "401", description = "작성자만 가능합니다.", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
+            @ApiResponse(responseCode = "400", description = "완료된 게시글" , content = @Content(schema = @Schema(implementation = SingleResponse.class)))
     })
     @Parameter(name = "post_id", description = "게시글 id", required = true, example = "1", in = ParameterIn.PATH)
     @Parameter(name = "offer_id", description = "offer id", required = true, example = "2", in = ParameterIn.PATH)
@@ -102,10 +98,9 @@ public class OfferController {
 
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "낙찰 완료, 게시글 마감", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
-            @ApiResponse(responseCode = "401", description = "작성자만 낙찰 가능합니다." + "<br>로그인이 필요합니다.",
-                    content = @Content(schema = @Schema(implementation = SingleResponse.class))),
-            @ApiResponse(responseCode = "400", description = "존재하지 않는 게시글" + "<br>완료된 게시글" + "<br>존재하지 않는 견적",
-                    content = @Content(schema = @Schema(implementation = SingleResponse.class)))
+            @ApiResponse(responseCode = "401", description = "작성자만 가능합니다." + "<br>로그인이 필요합니다.", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 게시글" + "<br>존재하지 않는 견적", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
+            @ApiResponse(responseCode = "400", description =  "완료된 게시글", content = @Content(schema = @Schema(implementation = SingleResponse.class)))
     })
     @Parameter(name = "post_id", description = "게시글 id", required = true, example = "1", in = ParameterIn.PATH)
     @Parameter(name = "offer_id", description = "offer id", required = true, example = "2", in = ParameterIn.PATH)

--- a/33ma3/src/main/java/softeer/be33ma3/controller/PostController.java
+++ b/33ma3/src/main/java/softeer/be33ma3/controller/PostController.java
@@ -36,8 +36,7 @@ public class PostController {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "게시글 목록 조회 성공", content = @Content(schema = @Schema(implementation = DataResponse.class))),
             @ApiResponse(responseCode = "400", description = "존재하지 않는 센터", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
-            @ApiResponse(responseCode = "500", description = "Internal Server Error",
-                    content = @Content(schema = @Schema(implementation = SingleResponse.class)))
+            @ApiResponse(responseCode = "500", description = "Internal Server Error", content = @Content(schema = @Schema(implementation = SingleResponse.class)))
     })
     @Operation(summary = "게시글 목록 조회", description = "게시글 목록 조회 메서드 입니다.")
     @GetMapping
@@ -53,8 +52,7 @@ public class PostController {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "게시글 작성 성공", content = @Content(schema = @Schema(implementation = DataResponse.class))),
             @ApiResponse(responseCode = "401", description = "센터는 글 작성이 불가능합니다.", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
-            @ApiResponse(responseCode = "400", description = "존재하지 않는 게시글" + "<br>존재하지 않는 회원" + "<br>존재하지 않는 구",
-                    content = @Content(schema = @Schema(implementation = SingleResponse.class)))
+            @ApiResponse(responseCode = "400", description = "존재하지 않는 게시글" + "<br>존재하지 않는 회원" + "<br>존재하지 않는 구", content = @Content(schema = @Schema(implementation = SingleResponse.class)))
     })
     @Operation(summary = "게시글 작성", description = "게시글 작성 메서드 입니다.")
     @PostMapping(value = "/create", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE})

--- a/33ma3/src/main/java/softeer/be33ma3/controller/PostController.java
+++ b/33ma3/src/main/java/softeer/be33ma3/controller/PostController.java
@@ -35,7 +35,7 @@ public class PostController {
 
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "게시글 목록 조회 성공", content = @Content(schema = @Schema(implementation = DataResponse.class))),
-            @ApiResponse(responseCode = "400", description = "존재하지 않는 센터", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 센터", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
             @ApiResponse(responseCode = "500", description = "Internal Server Error", content = @Content(schema = @Schema(implementation = SingleResponse.class)))
     })
     @Operation(summary = "게시글 목록 조회", description = "게시글 목록 조회 메서드 입니다.")
@@ -52,7 +52,7 @@ public class PostController {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "게시글 작성 성공", content = @Content(schema = @Schema(implementation = DataResponse.class))),
             @ApiResponse(responseCode = "401", description = "센터는 글 작성이 불가능합니다.", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
-            @ApiResponse(responseCode = "400", description = "존재하지 않는 게시글" + "<br>존재하지 않는 회원" + "<br>존재하지 않는 구", content = @Content(schema = @Schema(implementation = SingleResponse.class)))
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 게시글" + "<br>존재하지 않는 회원" + "<br>존재하지 않는 구", content = @Content(schema = @Schema(implementation = SingleResponse.class)))
     })
     @Operation(summary = "게시글 작성", description = "게시글 작성 메서드 입니다.")
     @PostMapping(value = "/create", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE})
@@ -64,7 +64,7 @@ public class PostController {
 
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "게시글 조회 완료", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
-            @ApiResponse(responseCode = "400", description = "존재하지 않는 게시글" + "<br>존재하지 않는 서비스 센터", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 게시글" + "<br>존재하지 않는 센터", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
             @ApiResponse(responseCode = "401", description = "경매 중인 게시글을 보려면 로그인해주세요.", content = @Content(schema = @Schema(implementation = SingleResponse.class)))
     })
     @Operation(summary = "게시글 조회", description = "게시글 조회 메서드 입니다.")
@@ -79,7 +79,8 @@ public class PostController {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "게시글 수정 성공", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
             @ApiResponse(responseCode = "401", description = "작성자만 가능합니다.", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
-            @ApiResponse(responseCode = "400", description = "존재하지 않는 게시글" + "<br>존재하지 않는 회원" + "<br>경매 시작 전에만 가능합니다.", content = @Content(schema = @Schema(implementation = SingleResponse.class)))
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 게시글" + "<br>존재하지 않는 센터", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
+            @ApiResponse(responseCode = "400", description = "경매 시작 전에만 가능합니다.", content = @Content(schema = @Schema(implementation = SingleResponse.class)))
     })
     @Operation(summary = "게시글 수정", description = "게시글 수정 메서드 입니다.")
     @Parameter(name = "post_id", description = "수정할 게시글 id", required = true, example = "1", in = ParameterIn.PATH)
@@ -93,7 +94,8 @@ public class PostController {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "게시글 삭제 성공", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
             @ApiResponse(responseCode = "401", description = "작성자만 가능합니다.", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
-            @ApiResponse(responseCode = "400", description = "존재하지 않는 게시글" + "<br>존재하지 않는 회원" + "<br>경매 시작 전에만 가능합니다.", content = @Content(schema = @Schema(implementation = SingleResponse.class)))
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 게시글" + "<br>존재하지 않는 센터", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
+            @ApiResponse(responseCode = "400", description = "경매 시작 전에만 가능합니다.", content = @Content(schema = @Schema(implementation = SingleResponse.class)))
     })
     @Operation(summary = "게시글 삭제", description = "게시글 삭제 메서드 입니다.")
     @Parameter(name = "post_id", description = "삭제할 게시글 id", required = true, example = "1", in = ParameterIn.PATH)

--- a/33ma3/src/main/java/softeer/be33ma3/exception/BusinessException.java
+++ b/33ma3/src/main/java/softeer/be33ma3/exception/BusinessException.java
@@ -1,0 +1,11 @@
+package softeer.be33ma3.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException{
+    protected ErrorCode errorCode;
+    public BusinessException(ErrorCode errorCode){
+        this.errorCode = errorCode;
+    }
+}

--- a/33ma3/src/main/java/softeer/be33ma3/exception/ControllerAdvice.java
+++ b/33ma3/src/main/java/softeer/be33ma3/exception/ControllerAdvice.java
@@ -1,7 +1,6 @@
 package softeer.be33ma3.exception;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.MessageSource;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -11,8 +10,6 @@ import softeer.be33ma3.response.SingleResponse;
 @RestControllerAdvice
 @RequiredArgsConstructor
 public class ControllerAdvice {
-    private final MessageSource ms;
-
     @ExceptionHandler(BusinessException.class)
     public ResponseEntity<?> handlerBizException(BusinessException e) {;
         return ResponseEntity.status(e.getErrorCode().getStatus()).body(SingleResponse.error(e.getErrorCode().getErrorMessage()));

--- a/33ma3/src/main/java/softeer/be33ma3/exception/ControllerAdvice.java
+++ b/33ma3/src/main/java/softeer/be33ma3/exception/ControllerAdvice.java
@@ -1,37 +1,20 @@
 package softeer.be33ma3.exception;
 
-import org.springframework.http.HttpStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.MessageSource;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import softeer.be33ma3.response.SingleResponse;
 
+
 @RestControllerAdvice
+@RequiredArgsConstructor
 public class ControllerAdvice {
+    private final MessageSource ms;
 
-    @ExceptionHandler(JwtTokenException.class)
-    public ResponseEntity<?> jwtUnAuthorized(JwtTokenException e){  //401
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(SingleResponse.error(e.getMessage()));
-    }
-  
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<?> methodArgumentNotValid(MethodArgumentNotValidException e){
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(SingleResponse.error(e.getFieldError().getDefaultMessage()));
-    }
-  
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<?> badRequest(RuntimeException e) {
-        return ResponseEntity.badRequest().body(SingleResponse.error(e.getMessage()));
-    }
-
-    @ExceptionHandler(UnauthorizedException.class)
-    public ResponseEntity<?> unauthorized(UnauthorizedException e) {
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(SingleResponse.error(e.getMessage()));
-    }
-
-    @ExceptionHandler(Exception.class)
-    public ResponseEntity<?> InternalServerError(Exception e) {
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(SingleResponse.error(e.getMessage()));
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<?> handlerBizException(BusinessException e) {;
+        return ResponseEntity.status(e.getErrorCode().getStatus()).body(SingleResponse.error(e.getErrorCode().getErrorMessage()));
     }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/exception/ErrorCode.java
+++ b/33ma3/src/main/java/softeer/be33ma3/exception/ErrorCode.java
@@ -1,7 +1,6 @@
 package softeer.be33ma3.exception;
 
 import lombok.Getter;
-import org.springframework.http.HttpRequest;
 import org.springframework.http.HttpStatus;
 
 @Getter

--- a/33ma3/src/main/java/softeer/be33ma3/exception/ErrorCode.java
+++ b/33ma3/src/main/java/softeer/be33ma3/exception/ErrorCode.java
@@ -37,7 +37,15 @@ public enum ErrorCode {
     CLOSED_POST(HttpStatus.BAD_REQUEST,"마감된 게시글"),
 
     //이미지
-    UNABLE_TO_CONVERT_FILE(HttpStatus.BAD_REQUEST,"파일을 변환할 수 없음");
+    UNABLE_TO_CONVERT_FILE(HttpStatus.BAD_REQUEST,"파일을 변환할 수 없음"),
+
+    //JWT
+    TOKEN_REQUIRED(HttpStatus.UNAUTHORIZED, "JWT 토큰 필요"),
+    JWT_NOT_VALID(HttpStatus.UNAUTHORIZED, "JWT_NOT_VALID"),
+    REFRESH_TOKEN_REQUIRED(HttpStatus.UNAUTHORIZED, "REFRESH TOKEN 필요"),
+    REFRESH_TOKEN_NOT_VALID(HttpStatus.UNAUTHORIZED, "올바르지 않은 리프레시 토큰"),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰");
+
 
     private final HttpStatus status;
     private final String errorMessage;

--- a/33ma3/src/main/java/softeer/be33ma3/exception/ErrorCode.java
+++ b/33ma3/src/main/java/softeer/be33ma3/exception/ErrorCode.java
@@ -1,45 +1,50 @@
 package softeer.be33ma3.exception;
 
 import lombok.Getter;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.HttpStatus;
 
 @Getter
 public enum ErrorCode {
     //공통
-    NOT_FOUND_CENTER("존재하지 않는 센터"),
-    NOT_FOUND_MEMBER("존재하지 않는 회원"),
-    AUTHOR_ONLY_ACCESS("작성자만 가능합니다."),
+    NOT_FOUND_CENTER(HttpStatus.NOT_FOUND,"존재하지 않는 센터"),
+    NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "존재하지 않는 회원"),
+    AUTHOR_ONLY_ACCESS(HttpStatus.UNAUTHORIZED ,"작성자만 가능합니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR"),
 
     //post
-    NOT_FOUND_POST("존재하지 않는 게시글"),
-    POST_CREATION_DISABLED("센터는 글 작성이 불가능합니다"),
-    LOGIN_REQUIRED("경매 중인 게시글을 보려면 로그인해주세요"),
-    PRE_AUCTION_ONLY("경매 시작 전에만 가능합니다."),
+    NOT_FOUND_POST(HttpStatus.NOT_FOUND, "존재하지 않는 게시글"),
+    POST_CREATION_DISABLED(HttpStatus.UNAUTHORIZED, "센터는 글 작성이 불가능합니다"),
+    LOGIN_REQUIRED(HttpStatus.UNAUTHORIZED, "경매 중인 게시글을 보려면 로그인해주세요"),
+    PRE_AUCTION_ONLY(HttpStatus.BAD_REQUEST,"경매 시작 전에만 가능합니다."),
 
     //위치
-    NOT_FOUND_REGION("존재하지 않는 구"),
-    NO_DISTRICT_IN_ADDRESS("주소에서 구를 찾을 수 없음"),
+    NOT_FOUND_REGION(HttpStatus.NOT_FOUND,"존재하지 않는 구"),
+    NO_DISTRICT_IN_ADDRESS(HttpStatus.BAD_REQUEST,"주소에서 구를 찾을 수 없음"),
 
     //채팅
-    ONLY_POST_AUTHOR_ALLOWED("게시글 작성자만 생성할 수 있습니다."),
-    NOT_FOUND_CHAT_ROOM("존재하지 않는 채팅 룸"),
-    NOT_A_MEMBER_OF_ROOM("해당 방의 회원이 아닙니다."),
+    ONLY_POST_AUTHOR_ALLOWED(HttpStatus.UNAUTHORIZED, "게시글 작성자만 생성할 수 있습니다."),
+    NOT_FOUND_CHAT_ROOM(HttpStatus.NOT_FOUND,"존재하지 않는 채팅 룸"),
+    NOT_A_MEMBER_OF_ROOM(HttpStatus.UNAUTHORIZED, "해당 방의 회원이 아닙니다."),
 
     //회원가입, 로그인
-    DUPLICATE_ID("이미 존재하는 아이디"),
-    ID_PASSWORD_MISMATCH("아이디 또는 비밀번호가 일치하지 않음"),
+    DUPLICATE_ID(HttpStatus.BAD_REQUEST,"이미 존재하는 아이디"),
+    ID_PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST,"아이디 또는 비밀번호가 일치하지 않음"),
 
     //견적
-    NOT_FOUND_OFFER("존재하지 않는 견적"),
-    ALREADY_SUBMITTED("이미 견적을 작성하였습니다."),
-    ONLY_LOWER_AMOUNT_ALLOWED("기존 금액보다 낮은 금액으로만 수정 가능합니다."),
-    CLOSED_POST("마감된 게시글"),
+    NOT_FOUND_OFFER(HttpStatus.NOT_FOUND,"존재하지 않는 견적"),
+    ALREADY_SUBMITTED(HttpStatus.UNAUTHORIZED, "이미 견적을 작성하였습니다."),
+    ONLY_LOWER_AMOUNT_ALLOWED(HttpStatus.BAD_REQUEST,"기존 금액보다 낮은 금액으로만 수정 가능합니다."),
+    CLOSED_POST(HttpStatus.BAD_REQUEST,"마감된 게시글"),
 
     //이미지
-    UNABLE_TO_CONVERT_FILE("파일을 변환할 수 없음");
+    UNABLE_TO_CONVERT_FILE(HttpStatus.BAD_REQUEST,"파일을 변환할 수 없음");
 
+    private final HttpStatus status;
     private final String errorMessage;
 
-    ErrorCode(String errorMessage) {
+    ErrorCode(HttpStatus status, String errorMessage) {
+        this.status = status;
         this.errorMessage = errorMessage;
     }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/exception/ErrorCode.java
+++ b/33ma3/src/main/java/softeer/be33ma3/exception/ErrorCode.java
@@ -9,7 +9,7 @@ public enum ErrorCode {
     NOT_FOUND_CENTER(HttpStatus.NOT_FOUND,"존재하지 않는 센터"),
     NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "존재하지 않는 회원"),
     AUTHOR_ONLY_ACCESS(HttpStatus.UNAUTHORIZED ,"작성자만 가능합니다."),
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR"),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal server error"),
 
     //post
     NOT_FOUND_POST(HttpStatus.NOT_FOUND, "존재하지 않는 게시글"),

--- a/33ma3/src/main/java/softeer/be33ma3/exception/ErrorCode.java
+++ b/33ma3/src/main/java/softeer/be33ma3/exception/ErrorCode.java
@@ -1,0 +1,45 @@
+package softeer.be33ma3.exception;
+
+import lombok.Getter;
+
+@Getter
+public enum ErrorCode {
+    //공통
+    NOT_FOUND_CENTER("존재하지 않는 센터"),
+    NOT_FOUND_MEMBER("존재하지 않는 회원"),
+    AUTHOR_ONLY_ACCESS("작성자만 가능합니다."),
+
+    //post
+    NOT_FOUND_POST("존재하지 않는 게시글"),
+    POST_CREATION_DISABLED("센터는 글 작성이 불가능합니다"),
+    LOGIN_REQUIRED("경매 중인 게시글을 보려면 로그인해주세요"),
+    PRE_AUCTION_ONLY("경매 시작 전에만 가능합니다."),
+
+    //위치
+    NOT_FOUND_REGION("존재하지 않는 구"),
+    NO_DISTRICT_IN_ADDRESS("주소에서 구를 찾을 수 없음"),
+
+    //채팅
+    ONLY_POST_AUTHOR_ALLOWED("게시글 작성자만 생성할 수 있습니다."),
+    NOT_FOUND_CHAT_ROOM("존재하지 않는 채팅 룸"),
+    NOT_A_MEMBER_OF_ROOM("해당 방의 회원이 아닙니다."),
+
+    //회원가입, 로그인
+    DUPLICATE_ID("이미 존재하는 아이디"),
+    ID_PASSWORD_MISMATCH("아이디 또는 비밀번호가 일치하지 않음"),
+
+    //견적
+    NOT_FOUND_OFFER("존재하지 않는 견적"),
+    ALREADY_SUBMITTED("이미 견적을 작성하였습니다."),
+    ONLY_LOWER_AMOUNT_ALLOWED("기존 금액보다 낮은 금액으로만 수정 가능합니다."),
+    CLOSED_POST("마감된 게시글"),
+
+    //이미지
+    UNABLE_TO_CONVERT_FILE("파일을 변환할 수 없음");
+
+    private final String errorMessage;
+
+    ErrorCode(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+}

--- a/33ma3/src/main/java/softeer/be33ma3/exception/ErrorCode.java
+++ b/33ma3/src/main/java/softeer/be33ma3/exception/ErrorCode.java
@@ -1,9 +1,11 @@
 package softeer.be33ma3.exception;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
 @Getter
+@RequiredArgsConstructor
 public enum ErrorCode {
     //공통
     NOT_FOUND_CENTER(HttpStatus.NOT_FOUND,"존재하지 않는 센터"),
@@ -49,9 +51,4 @@ public enum ErrorCode {
 
     private final HttpStatus status;
     private final String errorMessage;
-
-    ErrorCode(HttpStatus status, String errorMessage) {
-        this.status = status;
-        this.errorMessage = errorMessage;
-    }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/exception/JwtTokenException.java
+++ b/33ma3/src/main/java/softeer/be33ma3/exception/JwtTokenException.java
@@ -1,7 +1,0 @@
-package softeer.be33ma3.exception;
-
-public class JwtTokenException extends RuntimeException {
-    public JwtTokenException(String message) {
-        super(message);
-    }
-}

--- a/33ma3/src/main/java/softeer/be33ma3/exception/UnauthorizedException.java
+++ b/33ma3/src/main/java/softeer/be33ma3/exception/UnauthorizedException.java
@@ -1,8 +1,0 @@
-package softeer.be33ma3.exception;
-
-public class UnauthorizedException extends RuntimeException {
-
-    public UnauthorizedException(String message) {
-        super(message);
-    }
-}

--- a/33ma3/src/main/java/softeer/be33ma3/jwt/JwtProvider.java
+++ b/33ma3/src/main/java/softeer/be33ma3/jwt/JwtProvider.java
@@ -7,11 +7,14 @@ import io.jsonwebtoken.security.SignatureException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import softeer.be33ma3.exception.BusinessException;
 import softeer.be33ma3.repository.MemberRepository;
 
 import java.security.Key;
 import java.util.Date;
 
+import static softeer.be33ma3.exception.ErrorCode.EXPIRED_TOKEN;
+import static softeer.be33ma3.exception.ErrorCode.JWT_NOT_VALID;
 import static softeer.be33ma3.jwt.JwtProperties.*;
 @Slf4j
 @Component //빈으로 등록
@@ -54,11 +57,11 @@ public class JwtProvider {  //jwt 토큰을 만들고 검증하는 역할
             Jwts.parserBuilder().setSigningKey(key)
                     .build().parseClaimsJws(token).getBody();
         }catch (SignatureException e ){ //signature 검증에 실패한 경우
-            throw new JwtTokenException("JWT_NOT_VALID");
+            throw new BusinessException(JWT_NOT_VALID);
         }catch (ExpiredJwtException e) { //토큰이 만료된 경우
-            throw new JwtTokenException("만료된 토큰");
+            throw new BusinessException(EXPIRED_TOKEN);
         } catch (MalformedJwtException e) { //jwt 형식에 맞지 않는 경우
-            throw new JwtTokenException("JWT_NOT_VALID");
+            throw new BusinessException(JWT_NOT_VALID);
         }
 
         return true;

--- a/33ma3/src/main/java/softeer/be33ma3/jwt/JwtProvider.java
+++ b/33ma3/src/main/java/softeer/be33ma3/jwt/JwtProvider.java
@@ -7,7 +7,6 @@ import io.jsonwebtoken.security.SignatureException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-import softeer.be33ma3.exception.JwtTokenException;
 import softeer.be33ma3.repository.MemberRepository;
 
 import java.security.Key;

--- a/33ma3/src/main/java/softeer/be33ma3/jwt/JwtService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/jwt/JwtService.java
@@ -4,7 +4,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import softeer.be33ma3.domain.Member;
+import softeer.be33ma3.exception.BusinessException;
 import softeer.be33ma3.repository.MemberRepository;
+
+import static softeer.be33ma3.exception.ErrorCode.REFRESH_TOKEN_NOT_VALID;
 
 @Service
 @RequiredArgsConstructor
@@ -23,7 +26,7 @@ public class JwtService {
 
     @Transactional
     public String reissue(String refreshToken){   //리프레시 토큰으로 엑세스 토큰 재발급
-        Member member = memberRepository.findMemberByRefreshToken(refreshToken).orElseThrow(() -> new JwtTokenException("올바르지 않은 리프레시 토큰"));
+        Member member = memberRepository.findMemberByRefreshToken(refreshToken).orElseThrow(() -> new BusinessException(REFRESH_TOKEN_NOT_VALID));
 
         //토큰 생성
         String accessToken = jwtProvider.createAccessToken(member.getMemberType(), member.getMemberId(), member.getPassword());

--- a/33ma3/src/main/java/softeer/be33ma3/jwt/JwtService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/jwt/JwtService.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import softeer.be33ma3.domain.Member;
-import softeer.be33ma3.exception.JwtTokenException;
 import softeer.be33ma3.repository.MemberRepository;
 
 @Service

--- a/33ma3/src/main/java/softeer/be33ma3/jwt/intercepter/JwtAuthenticationInterceptor.java
+++ b/33ma3/src/main/java/softeer/be33ma3/jwt/intercepter/JwtAuthenticationInterceptor.java
@@ -7,8 +7,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.util.StringUtils;
 import org.springframework.web.cors.CorsUtils;
 import org.springframework.web.servlet.HandlerInterceptor;
+import softeer.be33ma3.exception.BusinessException;
 import softeer.be33ma3.jwt.JwtProvider;
 
+import static softeer.be33ma3.exception.ErrorCode.TOKEN_REQUIRED;
 import static softeer.be33ma3.jwt.JwtProperties.ACCESS_HEADER_STRING;
 import static softeer.be33ma3.jwt.JwtProperties.ACCESS_PREFIX_STRING;
 
@@ -25,7 +27,7 @@ public class JwtAuthenticationInterceptor implements HandlerInterceptor {
         String accessToken = getToken(request);
 
         if (accessToken == null) {    //헤더에 토큰이 없는 경우
-            throw new JwtTokenException("JWT 토큰 필요");
+            throw new BusinessException(TOKEN_REQUIRED);
         }
 
         if (StringUtils.hasText(accessToken)) {  //토큰이 있는 경우

--- a/33ma3/src/main/java/softeer/be33ma3/jwt/intercepter/JwtAuthenticationInterceptor.java
+++ b/33ma3/src/main/java/softeer/be33ma3/jwt/intercepter/JwtAuthenticationInterceptor.java
@@ -7,7 +7,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.util.StringUtils;
 import org.springframework.web.cors.CorsUtils;
 import org.springframework.web.servlet.HandlerInterceptor;
-import softeer.be33ma3.exception.JwtTokenException;
 import softeer.be33ma3.jwt.JwtProvider;
 
 import static softeer.be33ma3.jwt.JwtProperties.ACCESS_HEADER_STRING;

--- a/33ma3/src/main/java/softeer/be33ma3/jwt/intercepter/RefreshTokenAuthenticationInterceptor.java
+++ b/33ma3/src/main/java/softeer/be33ma3/jwt/intercepter/RefreshTokenAuthenticationInterceptor.java
@@ -7,10 +7,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.util.StringUtils;
 import org.springframework.web.servlet.HandlerInterceptor;
 import softeer.be33ma3.domain.Member;
+import softeer.be33ma3.exception.BusinessException;
 import softeer.be33ma3.jwt.JwtProvider;
 import softeer.be33ma3.repository.MemberRepository;
 
 
+import static softeer.be33ma3.exception.ErrorCode.JWT_NOT_VALID;
+import static softeer.be33ma3.exception.ErrorCode.REFRESH_TOKEN_REQUIRED;
 import static softeer.be33ma3.jwt.JwtProperties.REFRESH_HEADER_STRING;
 
 @RequiredArgsConstructor
@@ -25,7 +28,7 @@ public class RefreshTokenAuthenticationInterceptor implements HandlerInterceptor
             Claims claims = jwtProvider.getClaims(refreshToken);
 
             if (claims.get("memberId") == null) { //토큰에 memberId가 없는 경우
-                throw new JwtTokenException("JWT_NOT_VALID");
+                throw new BusinessException(JWT_NOT_VALID);
             }
 
             Long memberId = Long.valueOf(claims.get("memberId").toString());
@@ -40,7 +43,7 @@ public class RefreshTokenAuthenticationInterceptor implements HandlerInterceptor
     private String getToken(HttpServletRequest request) {
         String token = request.getHeader(REFRESH_HEADER_STRING);
         if (!StringUtils.hasText(token)) {
-            throw new JwtTokenException("REFRESH TOKEN 필요");
+            throw new BusinessException(REFRESH_TOKEN_REQUIRED);
         }
 
         return token;

--- a/33ma3/src/main/java/softeer/be33ma3/jwt/intercepter/RefreshTokenAuthenticationInterceptor.java
+++ b/33ma3/src/main/java/softeer/be33ma3/jwt/intercepter/RefreshTokenAuthenticationInterceptor.java
@@ -7,7 +7,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.util.StringUtils;
 import org.springframework.web.servlet.HandlerInterceptor;
 import softeer.be33ma3.domain.Member;
-import softeer.be33ma3.exception.JwtTokenException;
 import softeer.be33ma3.jwt.JwtProvider;
 import softeer.be33ma3.repository.MemberRepository;
 

--- a/33ma3/src/main/java/softeer/be33ma3/service/ChatService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/ChatService.java
@@ -7,6 +7,8 @@ import org.springframework.transaction.annotation.Transactional;
 import softeer.be33ma3.domain.*;
 import softeer.be33ma3.dto.response.ChatRoomListDto;
 import softeer.be33ma3.dto.response.ChatMessageResponseDto;
+import softeer.be33ma3.exception.BusinessException;
+import softeer.be33ma3.exception.ErrorCode;
 import softeer.be33ma3.exception.UnauthorizedException;
 import softeer.be33ma3.repository.*;
 import softeer.be33ma3.websocket.WebSocketHandler;
@@ -15,6 +17,7 @@ import softeer.be33ma3.websocket.WebSocketRepository;
 import java.util.ArrayList;
 import java.util.List;
 
+import static softeer.be33ma3.exception.ErrorCode.NOT_FOUND_CENTER;
 import static softeer.be33ma3.service.MemberService.CENTER_TYPE;
 import static softeer.be33ma3.service.MemberService.CLIENT_TYPE;
 
@@ -34,7 +37,7 @@ public class ChatService {
 
     @Transactional
     public Long createRoom(Member client, Long centerId, Long postId) {
-        Member center = memberRepository.findById(centerId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 센터"));
+        Member center = memberRepository.findById(centerId).orElseThrow(() -> new BusinessException(NOT_FOUND_CENTER));
         Post post = postRepository.findById(postId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글"));
 
         if(!post.getMember().equals(client)){

--- a/33ma3/src/main/java/softeer/be33ma3/service/MemberService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/MemberService.java
@@ -10,10 +10,14 @@ import softeer.be33ma3.dto.request.CenterSignUpDto;
 import softeer.be33ma3.dto.request.LoginDto;
 import softeer.be33ma3.dto.request.ClientSignUpDto;
 import softeer.be33ma3.dto.response.LoginSuccessDto;
+import softeer.be33ma3.exception.BusinessException;
 import softeer.be33ma3.jwt.JwtService;
 import softeer.be33ma3.jwt.JwtToken;
 import softeer.be33ma3.repository.CenterRepository;
 import softeer.be33ma3.repository.MemberRepository;
+
+import static softeer.be33ma3.exception.ErrorCode.DUPLICATE_ID;
+import static softeer.be33ma3.exception.ErrorCode.ID_PASSWORD_MISMATCH;
 
 @Service
 @RequiredArgsConstructor
@@ -29,7 +33,7 @@ public class MemberService {
     @Transactional
     public void clientSignUp(ClientSignUpDto clientSignUpDto) {
         if (memberRepository.findMemberByLoginId(clientSignUpDto.getLoginId()).isPresent()) {//아이디가 이미 존재하는 경우
-            throw new IllegalArgumentException("이미 존재하는 아이디");
+            throw new BusinessException(DUPLICATE_ID);
         }
 
         Member member = Member.createMember(CLIENT_TYPE, clientSignUpDto.getLoginId(), clientSignUpDto.getPassword());
@@ -39,7 +43,7 @@ public class MemberService {
     @Transactional
     public void centerSignUp(CenterSignUpDto centerSignUpDto) {
         if (memberRepository.findMemberByLoginId(centerSignUpDto.getLoginId()).isPresent()) {
-            throw new IllegalArgumentException("이미 존재하는 아이디");
+            throw new BusinessException(DUPLICATE_ID);
         }
 
         Member member = Member.createMember(CENTER_TYPE, centerSignUpDto.getLoginId(), centerSignUpDto.getPassword());
@@ -52,7 +56,7 @@ public class MemberService {
     @Transactional
     public LoginSuccessDto login(LoginDto loginDto) {
         Member member = memberRepository.findByLoginIdAndPassword(loginDto.getLoginId(), loginDto.getPassword())
-                .orElseThrow(() -> new IllegalArgumentException("아이디 또는 비밀번호가 일치하지 않음"));
+                .orElseThrow(() -> new BusinessException(ID_PASSWORD_MISMATCH));
 
         JwtToken jwtToken = jwtService.getJwtToken(member.getMemberType(), member.getMemberId(), loginDto.getLoginId());
         member.setRefreshToken(jwtToken.getRefreshToken()); //리프레시 토큰 저장

--- a/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import softeer.be33ma3.dto.response.AvgPriceDto;
+import softeer.be33ma3.exception.BusinessException;
 import softeer.be33ma3.websocket.WebSocketHandler;
 import softeer.be33ma3.domain.Center;
 import softeer.be33ma3.domain.Member;
@@ -22,6 +23,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static softeer.be33ma3.exception.ErrorCode.*;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -36,9 +39,9 @@ public class OfferService {
     // 견적 제시 댓글 하나 반환
     public OfferDetailDto showOffer(Long postId, Long offerId) {
         // 1. 해당 게시글 가져오기
-        postRepository.findById(postId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글"));
+        postRepository.findById(postId).orElseThrow(() -> new BusinessException(NOT_FOUND_POST));
         // 2. 해당 댓글 가져오기
-        Offer offer = offerRepository.findById(offerId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 견적"));
+        Offer offer = offerRepository.findById(offerId).orElseThrow(() -> new BusinessException(NOT_FOUND_OFFER);
         return OfferDetailDto.fromEntity(offer);
     }
 
@@ -48,10 +51,9 @@ public class OfferService {
         // 1. 해당 게시글이 마감 전인지 확인
         Post post = checkNotDonePost(postId);
         // 2. 센터 정보 가져오기
-        Center center = centerRepository.findByMember_MemberId(member.getMemberId()).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 센터"));
+        Center center = centerRepository.findByMember_MemberId(member.getMemberId()).orElseThrow(() -> new BusinessException(NOT_FOUND_CENTER));
         // 3. 이미 견적을 작성한 센터인지 검증
-        offerRepository.findByPost_PostIdAndCenter_CenterId(postId, center.getCenterId())
-                .ifPresent(offer -> {throw new UnauthorizedException("이미 견적을 작성하였습니다.");});
+        offerRepository.findByPost_PostIdAndCenter_CenterId(postId, center.getCenterId()).ifPresent(offer -> {throw new BusinessException(ALREADY_SUBMITTED);});
         // 4. 댓글 생성하여 저장하기
         Offer offer = offerCreateDto.toEntity(post, center);
         Offer savedOffer = offerRepository.save(offer);
@@ -64,14 +66,14 @@ public class OfferService {
         // 1. 해당 게시글이 마감 전인지 확인
         checkNotDonePost(postId);
         // 2. 센터 정보 가져오기
-        Center center = centerRepository.findByMember_MemberId(member.getMemberId()).orElseThrow(() ->  new IllegalArgumentException("존재하지 않는 센터"));
+        Center center = centerRepository.findByMember_MemberId(member.getMemberId()).orElseThrow(() ->  new BusinessException(NOT_FOUND_CENTER)));
         // 3. 기존 댓글 가져오기
-        Offer offer = offerRepository.findById(offerId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 견적"));
+        Offer offer = offerRepository.findById(offerId).orElseThrow(() -> new BusinessException(NOT_FOUND_OFFER));
         // 4. 수정 가능한지 검증
         if(center.getCenterId() != offer.getCenter().getCenterId())
-            throw new UnauthorizedException("작성자만 가능합니다.");
+            throw new BusinessException(AUTHOR_ONLY_ACCESS);
         if(offerCreateDto.getPrice() > offer.getPrice())
-            throw new IllegalArgumentException("기존 금액보다 낮은 금액으로만 수정 가능합니다.");
+            throw new BusinessException(ONLY_LOWER_AMOUNT_ALLOWED);
         // 5. 댓글 수정하기
         offer.setPrice(offerCreateDto.getPrice());
         offer.setContents(offerCreateDto.getContents());
@@ -84,12 +86,12 @@ public class OfferService {
         // 1. 해당 게시글이 마감 전인지 확인
         checkNotDonePost(postId);
         // 2. 센터 정보 가져오기
-        Center center = centerRepository.findByMember_MemberId(member.getMemberId()).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 센터"));
+        Center center = centerRepository.findByMember_MemberId(member.getMemberId()).orElseThrow(() -> new BusinessException(NOT_FOUND_CENTER));
         // 3. 기존 댓글 가져오기
-        Offer offer = offerRepository.findById(offerId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 견적"));
+        Offer offer = offerRepository.findById(offerId).orElseThrow(() -> new BusinessException(NOT_FOUND_OFFER));
         // 4. 댓글 작성자인지 검증
         if(!offer.getCenter().equals(center))
-            throw new UnauthorizedException("작성자만 가능합니다.");
+            throw new BusinessException(AUTHOR_ONLY_ACCESS);
         // 5. 댓글 삭제
         offerRepository.delete(offer);
     }
@@ -101,9 +103,9 @@ public class OfferService {
         Post post = checkNotDonePost(postId);
         // 3. 게시글 작성자의 접근인지 검증
         if(member.getMemberId() != post.getMember().getMemberId())
-            throw new UnauthorizedException("작성자만 가능합니다.");
+            throw new BusinessException(AUTHOR_ONLY_ACCESS);
         // 4. 낙찰을 희망하는 댓글 가져오기
-        Offer offer = offerRepository.findById(offerId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 견적"));
+        Offer offer = offerRepository.findById(offerId).orElseThrow(() -> new BusinessException(NOT_FOUND_OFFER));
         // 5. 댓글 낙찰, 게시글 마감 처리
         offer.setSelected();
         post.setDone();
@@ -115,9 +117,9 @@ public class OfferService {
 
     // 해당 게시글을 가져오고, 마감 전인지 판단
     private Post checkNotDonePost(Long postId) {
-        Post post = postRepository.findById(postId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글"));
+        Post post = postRepository.findById(postId).orElseThrow(() -> new BusinessException(NOT_FOUND_POST));
         if(post.isDone())
-            throw new IllegalArgumentException("마감된 게시글");
+            throw new BusinessException(CLOSED_POST);
         return post;
     }
 
@@ -141,7 +143,7 @@ public class OfferService {
 
     public void sendAboutOfferUpdate(Long postId) {
         // 1. 해당 게시글 가져오기
-        Post post = postRepository.findById(postId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글"));
+        Post post = postRepository.findById(postId).orElseThrow(() -> new BusinessException(NOT_FOUND_POST));
         // 2. 글 작성자 아이디 가져오기
         Long writerId = post.getMember().getMemberId();
         // 3. 글 작성자에게 업데이트된 댓글 목록 실시간 전송

--- a/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
@@ -70,7 +70,7 @@ public class OfferService {
         Offer offer = offerRepository.findById(offerId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 견적"));
         // 4. 수정 가능한지 검증
         if(center.getCenterId() != offer.getCenter().getCenterId())
-            throw new UnauthorizedException("작성자만 수정 가능합니다.");
+            throw new UnauthorizedException("작성자만 가능합니다.");
         if(offerCreateDto.getPrice() > offer.getPrice())
             throw new IllegalArgumentException("기존 금액보다 낮은 금액으로만 수정 가능합니다.");
         // 5. 댓글 수정하기
@@ -90,7 +90,7 @@ public class OfferService {
         Offer offer = offerRepository.findById(offerId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 견적"));
         // 4. 댓글 작성자인지 검증
         if(!offer.getCenter().equals(center))
-            throw new UnauthorizedException("작성자만 삭제 가능합니다.");
+            throw new UnauthorizedException("작성자만 가능합니다.");
         // 5. 댓글 삭제
         offerRepository.delete(offer);
     }
@@ -102,7 +102,7 @@ public class OfferService {
         Post post = checkNotDonePost(postId);
         // 3. 게시글 작성자의 접근인지 검증
         if(member.getMemberId() != post.getMember().getMemberId())
-            throw new UnauthorizedException("작성자만 낙찰 가능합니다.");
+            throw new UnauthorizedException("작성자만 가능합니다.");
         // 4. 낙찰을 희망하는 댓글 가져오기
         Offer offer = offerRepository.findById(offerId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 견적"));
         // 5. 댓글 낙찰, 게시글 마감 처리
@@ -118,7 +118,7 @@ public class OfferService {
     private Post checkNotDonePost(Long postId) {
         Post post = postRepository.findById(postId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글"));
         if(post.isDone())
-            throw new IllegalArgumentException("완료된 게시글");
+            throw new IllegalArgumentException("마감된 게시글");
         return post;
     }
 

--- a/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
@@ -12,7 +12,6 @@ import softeer.be33ma3.domain.Offer;
 import softeer.be33ma3.domain.Post;
 import softeer.be33ma3.dto.request.OfferCreateDto;
 import softeer.be33ma3.dto.response.OfferDetailDto;
-import softeer.be33ma3.exception.UnauthorizedException;
 import softeer.be33ma3.repository.CenterRepository;
 import softeer.be33ma3.repository.OfferRepository;
 import softeer.be33ma3.repository.PostRepository;

--- a/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
@@ -41,7 +41,7 @@ public class OfferService {
         // 1. 해당 게시글 가져오기
         postRepository.findById(postId).orElseThrow(() -> new BusinessException(NOT_FOUND_POST));
         // 2. 해당 댓글 가져오기
-        Offer offer = offerRepository.findById(offerId).orElseThrow(() -> new BusinessException(NOT_FOUND_OFFER);
+        Offer offer = offerRepository.findById(offerId).orElseThrow(() -> new BusinessException(NOT_FOUND_OFFER));
         return OfferDetailDto.fromEntity(offer);
     }
 
@@ -66,7 +66,7 @@ public class OfferService {
         // 1. 해당 게시글이 마감 전인지 확인
         checkNotDonePost(postId);
         // 2. 센터 정보 가져오기
-        Center center = centerRepository.findByMember_MemberId(member.getMemberId()).orElseThrow(() ->  new BusinessException(NOT_FOUND_CENTER)));
+        Center center = centerRepository.findByMember_MemberId(member.getMemberId()).orElseThrow(() ->  new BusinessException(NOT_FOUND_CENTER));
         // 3. 기존 댓글 가져오기
         Offer offer = offerRepository.findById(offerId).orElseThrow(() -> new BusinessException(NOT_FOUND_OFFER));
         // 4. 수정 가능한지 검증

--- a/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
@@ -139,7 +139,7 @@ public class PostService {
             return null;
         // 센터 엔티티 찾기
         Center center = centerRepository.findByMember_MemberId(member.getMemberId())
-                .orElseThrow(()->new IllegalArgumentException("존재하지 않는 서비스 센터"));
+                .orElseThrow(()->new IllegalArgumentException("존재하지 않는 센터"));
         // 해당 게시글에 해당 센터가 작성한 견적 찾기
         Optional<Offer> offer = offerRepository.findByPost_PostIdAndCenter_CenterId(postId, center.getCenterId());
         return (offer.isEmpty() ? null : OfferDetailDto.fromEntity(offer.get()));

--- a/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
@@ -8,7 +8,6 @@ import org.springframework.web.multipart.MultipartFile;
 import softeer.be33ma3.domain.*;
 import softeer.be33ma3.dto.request.PostCreateDto;
 import softeer.be33ma3.dto.response.*;
-import softeer.be33ma3.exception.UnauthorizedException;
 import softeer.be33ma3.repository.*;
 
 import java.util.*;

--- a/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
@@ -8,6 +8,7 @@ import org.springframework.web.multipart.MultipartFile;
 import softeer.be33ma3.domain.*;
 import softeer.be33ma3.dto.request.PostCreateDto;
 import softeer.be33ma3.dto.response.*;
+import softeer.be33ma3.exception.BusinessException;
 import softeer.be33ma3.repository.*;
 
 import java.util.*;
@@ -16,6 +17,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.List;
 
+import static softeer.be33ma3.exception.ErrorCode.*;
 import static softeer.be33ma3.service.MemberService.CENTER_TYPE;
 
 @Service
@@ -37,7 +39,7 @@ public class PostService {
         List<String> tuneUps = stringCommaParsing(tuneUp);
         List<Long> postIds = null;
         if(member != null && member.getMemberType() == CENTER_TYPE) {
-            Center center = centerRepository.findByMember_MemberId(member.getMemberId()).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 센터"));
+            Center center = centerRepository.findByMember_MemberId(member.getMemberId()).orElseThrow(() -> new BusinessException(NOT_FOUND_CENTER));
             postIds = postPerCenterRepository.findPostIdsByCenterId(center.getCenterId());
         }
         List<Post> posts = postRepository.findAllByConditions(done, regions, repairs, tuneUps, postIds);
@@ -64,7 +66,7 @@ public class PostService {
     public Long createPost(Member currentMember, PostCreateDto postCreateDto, List<MultipartFile> multipartFiles) {
         //회원이랑 지역 찾기
         if(currentMember.getMemberType() == CENTER_TYPE){
-            throw new UnauthorizedException("센터는 글 작성이 불가능합니다.");
+            throw new BusinessException(POST_CREATION_DISABLED);
         }
         Region region = getRegion(postCreateDto.getLocation());
 
@@ -85,7 +87,6 @@ public class PostService {
         return savedPost.getPostId();
     }
 
-
     @Transactional
     public void editPost(Member member, Long postId, PostCreateDto postCreateDto) {
         Post post = validPostAndMember(member, postId);
@@ -93,6 +94,7 @@ public class PostService {
         Region region = getRegion(postCreateDto.getLocation());
         post.editPost(postCreateDto, region);
     }
+
     @Transactional
     public void deletePost(Member member, Long postId) {
         Post post = validPostAndMember(member, postId);
@@ -107,9 +109,9 @@ public class PostService {
     // 게시글 세부사항 반환 (로그인 하지 않아도 확인 가능)
     public Object showPost(Long postId, Member member) {
         // 1. 게시글 존재 유무 판단
-        Post post = postRepository.findById(postId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글"));
+        Post post = postRepository.findById(postId).orElseThrow(() -> new BusinessException(NOT_FOUND_POST));
         if(member == null && !post.isDone())
-            throw new UnauthorizedException("경매 중인 게시글을 보려면 로그인해주세요.");
+            throw new BusinessException(LOGIN_REQUIRED);
         // 2. 게시글 세부 사항 가져오기
         List<String> repairList = stringCommaParsing(post.getRepairService());
         List<String> tuneUpList = stringCommaParsing(post.getTuneUpService());
@@ -138,7 +140,7 @@ public class PostService {
             return null;
         // 센터 엔티티 찾기
         Center center = centerRepository.findByMember_MemberId(member.getMemberId())
-                .orElseThrow(()->new IllegalArgumentException("존재하지 않는 센터"));
+                .orElseThrow(()->new BusinessException(NOT_FOUND_CENTER));
         // 해당 게시글에 해당 센터가 작성한 견적 찾기
         Optional<Offer> offer = offerRepository.findByPost_PostIdAndCenter_CenterId(postId, center.getCenterId());
         return (offer.isEmpty() ? null : OfferDetailDto.fromEntity(offer.get()));
@@ -150,10 +152,10 @@ public class PostService {
         Matcher matcher = pattern.matcher(location);
 
         if (matcher.find()) {
-            return regionRepository.findByRegionName(matcher.group()).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 구"));
+            return regionRepository.findByRegionName(matcher.group()).orElseThrow(() -> new BusinessException(NOT_FOUND_REGION));
         }
 
-        throw new IllegalArgumentException("주소에서 구를 찾을 수 없음");
+        throw new BusinessException(NO_DISTRICT_IN_ADDRESS);
     }
 
     private void centerAndPostMapping(PostCreateDto postCreateDto, Post savedPost) {
@@ -167,14 +169,14 @@ public class PostService {
     }
 
     private Post validPostAndMember(Member member, Long postId) {
-        Post post = postRepository.findById(postId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글"));
+        Post post = postRepository.findById(postId).orElseThrow(() -> new BusinessException(NOT_FOUND_POST));
 
         if (!post.getMember().equals(member)) {
-            throw new UnauthorizedException("작성자만 가능합니다.");
+            throw new BusinessException(AUTHOR_ONLY_ACCESS);
         }
 
         if (!offerRepository.findByPost_PostId(postId).isEmpty()) { //댓글이 있는 경우(경매 시작 후)
-            throw new IllegalArgumentException("경매 시작 전에만 가능합니다.");
+            throw new BusinessException(PRE_AUCTION_ONLY);
         }
 
         return post;

--- a/33ma3/src/main/java/softeer/be33ma3/service/S3Service.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/S3Service.java
@@ -9,10 +9,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
+import softeer.be33ma3.exception.BusinessException;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.UUID;
+
+import static softeer.be33ma3.exception.ErrorCode.UNABLE_TO_CONVERT_FILE;
 
 @RequiredArgsConstructor
 @Component
@@ -37,7 +40,7 @@ public class S3Service {
             amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, inputStream, objectMetadata)
                             .withCannedAcl(CannedAccessControlList.PublicReadWrite));
         } catch (IOException e) {
-            throw new IllegalArgumentException("파일을 변환할 수 없음");
+            throw new BusinessException(UNABLE_TO_CONVERT_FILE);
         }
 
         return fileName;

--- a/33ma3/src/test/java/softeer/be33ma3/service/PostServiceTest.java
+++ b/33ma3/src/test/java/softeer/be33ma3/service/PostServiceTest.java
@@ -11,7 +11,6 @@ import softeer.be33ma3.domain.Member;
 import softeer.be33ma3.domain.Post;
 import softeer.be33ma3.domain.Region;
 import softeer.be33ma3.dto.request.PostCreateDto;
-import softeer.be33ma3.exception.UnauthorizedException;
 import softeer.be33ma3.repository.MemberRepository;
 import softeer.be33ma3.repository.PostRepository;
 import softeer.be33ma3.repository.RegionRepository;


### PR DESCRIPTION

## 구현 내용
- [x] BusinessException 클래스 구현
- [x] ErrorCode 이넘 구현 -> 상태코드와 메세지를 가짐
- [x] 스웨거 수정

## 고민 사항
처음에는 에러 코드만 이넘으로 관리하여 변경하려고 했는데 겟터를 사용해서 메세지를 가져와야 했다. 그런 부분이 가독성을 해친다고 생각하였고, 해결하기 위해서 방법을 찾아보던 중 지금과 같은 방법으로 해결하기로 했다!
모든 예외는 BusinessException을 던지는 것으로 처리하였다. 이 클래스는 이넘을 넘겨 받고 controllerAdvice에서 전달된 이넘의 상태코드와 메세지를 반환하도록 했다! 이 방법을 사용함으로써 겟터를 사용하지 않고 이넘을 바로 넘겨줄 수 있었고, 새로운 예외를 생성할때마다 예외 클래스를 생성했어야 했는데 이부분도 해결할 수 있었다~

## 기타
존재하지 않는 xx 같은 부분은 기존에 400이였는데 404로 변경했다