### PR TITLE
Offer 관련 테스트 코드 작성, 웹 소켓 관련 로그 추가, 평균 견적 제시가 계산 메소드 수정 #38

### DIFF
--- a/33ma3/src/main/java/softeer/be33ma3/controller/OfferController.java
+++ b/33ma3/src/main/java/softeer/be33ma3/controller/OfferController.java
@@ -101,7 +101,7 @@ public class OfferController {
     }
 
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "낙찰 완료, 게시글 마감", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
+            @ApiResponse(responseCode = "200", description = "낙찰 완료, 게시글 마감", content = @Content(schema = @Schema(implementation = DataResponse.class))),
             @ApiResponse(responseCode = "401", description = "작성자만 낙찰 가능합니다." + "<br>로그인이 필요합니다.",
                     content = @Content(schema = @Schema(implementation = SingleResponse.class))),
             @ApiResponse(responseCode = "400", description = "존재하지 않는 게시글" + "<br>완료된 게시글" + "<br>존재하지 않는 견적",
@@ -115,6 +115,6 @@ public class OfferController {
                                          @PathVariable("offer_id") Long offerId,
                                          @Schema(hidden = true) @CurrentUser Member member) {
         offerService.selectOffer(postId, offerId, member);
-        return ResponseEntity.ok(SingleResponse.success("낙찰 완료, 게시글 마감"));
+        return ResponseEntity.ok(DataResponse.success("낙찰 완료, 게시글 마감", postId));
     }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/repository/OfferRepository.java
+++ b/33ma3/src/main/java/softeer/be33ma3/repository/OfferRepository.java
@@ -8,6 +8,6 @@ import java.util.Optional;
 
 public interface OfferRepository extends JpaRepository<Offer, Long> {
     List<Offer> findByPost_PostId(Long postId);
-    Optional<Offer> findByPost_PostIdAndCenter_CenterId(Long postId, long centerId);
+    Optional<Offer> findByPost_PostIdAndCenter_CenterId(Long postId, Long centerId);
     Optional<Offer> findByPost_PostIdAndOfferId(Long postId, Long offerId);
 }

--- a/33ma3/src/main/java/softeer/be33ma3/repository/OfferRepository.java
+++ b/33ma3/src/main/java/softeer/be33ma3/repository/OfferRepository.java
@@ -9,4 +9,5 @@ import java.util.Optional;
 public interface OfferRepository extends JpaRepository<Offer, Long> {
     List<Offer> findByPost_PostId(Long postId);
     Optional<Offer> findByPost_PostIdAndCenter_CenterId(Long postId, long centerId);
+    Optional<Offer> findByPost_PostIdAndOfferId(Long postId, Long offerId);
 }

--- a/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
@@ -132,12 +132,10 @@ public class OfferService {
     // 견적 제시 댓글 목록의 평균 제시 가격 계산하여 반환하기
     public static double calculateAvgPrice(List<Offer> offerList) {
         // 제시 가격의 합계, 개수 구하기
-        IntSummaryStatistics stats = offerList.stream()
-                .collect(Collectors.summarizingInt(Offer::getPrice));
-
-        if(stats.getSum() == 0)
-            return 0;
-        return Math.round(stats.getAverage() * 10) / 10.0;      // 소수점 첫째 자리까지 반올림
+        if(offerList.isEmpty())
+            return 0.0;
+        int total = offerList.stream().mapToInt(Offer::getPrice).sum();
+        return Math.round((double)total/offerList.size() * 10) / 10.0;      // 소수점 첫째 자리까지 반올림
     }
 
     public void sendAboutOfferUpdate(Long postId) {

--- a/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
@@ -39,7 +39,7 @@ public class OfferService {
         // 1. 해당 게시글 가져오기
         postRepository.findById(postId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글"));
         // 2. 해당 댓글 가져오기
-        Offer offer = offerRepository.findById(offerId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 견적"));
+        Offer offer = offerRepository.findByPost_PostIdAndOfferId(postId, offerId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 견적"));
         return OfferDetailDto.fromEntity(offer);
     }
 
@@ -67,7 +67,7 @@ public class OfferService {
         // 2. 센터 정보 가져오기
         Center center = centerRepository.findByMember_MemberId(member.getMemberId()).orElseThrow(() ->  new IllegalArgumentException("존재하지 않는 센터"));
         // 3. 기존 댓글 가져오기
-        Offer offer = offerRepository.findById(offerId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 견적"));
+        Offer offer = offerRepository.findByPost_PostIdAndOfferId(postId, offerId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 견적"));
         // 4. 수정 가능한지 검증
         if(center.getCenterId() != offer.getCenter().getCenterId())
             throw new UnauthorizedException("작성자만 수정 가능합니다.");
@@ -87,7 +87,7 @@ public class OfferService {
         // 2. 센터 정보 가져오기
         Center center = centerRepository.findByMember_MemberId(member.getMemberId()).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 센터"));
         // 3. 기존 댓글 가져오기
-        Offer offer = offerRepository.findById(offerId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 견적"));
+        Offer offer = offerRepository.findByPost_PostIdAndOfferId(postId, offerId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 견적"));
         // 4. 댓글 작성자인지 검증
         if(!offer.getCenter().equals(center))
             throw new UnauthorizedException("작성자만 삭제 가능합니다.");
@@ -104,7 +104,7 @@ public class OfferService {
         if(member.getMemberId() != post.getMember().getMemberId())
             throw new UnauthorizedException("작성자만 낙찰 가능합니다.");
         // 4. 낙찰을 희망하는 댓글 가져오기
-        Offer offer = offerRepository.findById(offerId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 견적"));
+        Offer offer = offerRepository.findByPost_PostIdAndOfferId(postId, offerId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 견적"));
         // 5. 댓글 낙찰, 게시글 마감 처리
         offer.setSelected();
         post.setDone();

--- a/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
@@ -184,10 +184,10 @@ public class OfferService {
     // 낙찰 처리 후 서비스 센터들에게 낙찰 메세지, 경매 마감 메세지 전송
     private void sendMessageAfterSelection(Long postId, Long selectedMemberId) {
         // 낙찰 메세지
-        DataResponse<Long> selectAlert = DataResponse.success("제시한 견적이 낙찰되었습니다.", postId);
+        DataResponse<Boolean> selectAlert = DataResponse.success("제시한 견적이 낙찰되었습니다.", true);
         webSocketHandler.sendData2Client(selectedMemberId, selectAlert);
         // 경매 마감 메세지
-        DataResponse<Long> endAlert = DataResponse.success("견적 미선정으로 경매가 마감되었습니다. 다음 기회를 노려보세요!", postId);
+        DataResponse<Boolean> endAlert = DataResponse.success("견적 미선정으로 경매가 마감되었습니다. 다음 기회를 노려보세요!", false);
         List<Offer> offerList = offerRepository.findByPost_PostId(postId);
         List<Long> memberIdsInPost = findMemberIdsWithOfferList(offerList);
         memberIdsInPost.stream()

--- a/33ma3/src/main/java/softeer/be33ma3/websocket/ExitMember.java
+++ b/33ma3/src/main/java/softeer/be33ma3/websocket/ExitMember.java
@@ -1,12 +1,16 @@
 package softeer.be33ma3.websocket;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
 @NoArgsConstructor
 public class ExitMember {
+    @JsonProperty("type")
     private String type;
+    @JsonProperty("roomId")
     private Long roomId;
+    @JsonProperty("memberId")
     private Long memberId;
 }

--- a/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketRepository.java
+++ b/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketRepository.java
@@ -28,6 +28,7 @@ public class WebSocketRepository {
         members.add(memberId);
         postRoom.put(postId, members);
         log.info("{}번 게시글에 {}번 유저 입장", postId, memberId);
+        log.info("{}번 게시글에 들어와있는 유저: {}명", postId, postRoom.get(postId).size());
     }
 
     public void saveMemberInChat(Long roomId, Long memberId) {
@@ -43,6 +44,7 @@ public class WebSocketRepository {
     public void saveSessionWithMemberId(Long memberId, WebSocketSession webSocketSession) {
         sessions.put(memberId, webSocketSession);
         log.info("{}번 유저 웹소켓 세션 저장 성공", memberId);
+        log.info("웹소켓 세션 저장소 크기: {}" , sessions.size());
     }
 
     public WebSocketSession findSessionByMemberId(Long memberId) {

--- a/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketService.java
@@ -22,10 +22,12 @@ public class WebSocketService {
         String payload = message.getPayload();
         // 게시글 관련 웹 소켓 연결이 종료된 유저가 있다고 메세지를 받았을 경우
         if(payload.contains("post") && payload.contains("memberId")) {
+            log.info("게시글에서 유저가 나갔습니다.");
             ExitMember exitMember = objectMapper.readValue(payload, ExitMember.class);
             closePostConnection(exitMember.getRoomId(), exitMember.getMemberId());
         }
         if(payload.contains("chat") && payload.contains("memberId")) {
+            log.info("채팅방에서 유저가 나갔습니다.");
             ExitMember exitMember = objectMapper.readValue(payload, ExitMember.class);
             closeChatConnection(exitMember.getRoomId(), exitMember.getMemberId());
         }

--- a/33ma3/src/test/java/softeer/be33ma3/dto/response/OfferDetailDtoTest.java
+++ b/33ma3/src/test/java/softeer/be33ma3/dto/response/OfferDetailDtoTest.java
@@ -9,6 +9,7 @@ import org.springframework.test.context.ActiveProfiles;
 import softeer.be33ma3.domain.Center;
 import softeer.be33ma3.domain.Member;
 import softeer.be33ma3.domain.Offer;
+import softeer.be33ma3.domain.Post;
 import softeer.be33ma3.repository.CenterRepository;
 import softeer.be33ma3.repository.MemberRepository;
 import softeer.be33ma3.repository.OfferRepository;
@@ -44,7 +45,7 @@ class OfferDetailDtoTest {
         Member savedMember = memberRepository.save(member);
         Center center = Center.createCenter("center1", 0.0, 0.0, savedMember);
         Center savedCenter = centerRepository.save(center);
-        Offer savedOffer = createOffer(10, "offer1", savedCenter);
+        Offer savedOffer = createOffer(10, "offer1", null, savedCenter);
         // when
         OfferDetailDto actual = OfferDetailDto.fromEntity(savedOffer);
         // then
@@ -65,9 +66,9 @@ class OfferDetailDtoTest {
         Center center2 = Center.createCenter("center2", 0.0, 0.0, members.get(1));
         Center center3 = Center.createCenter("center3", 0.0, 0.0, members.get(2));
         List<Center> centers = centerRepository.saveAll(List.of(center1, center2, center3));
-        Offer offer1 = createOffer(3, "offer1", centers.get(0));
-        Offer offer2 = createOffer(2, "offer2", centers.get(1));
-        Offer offer3 = createOffer(1, "offer3", centers.get(2));
+        Offer offer1 = createOffer(3, "offer1", null, centers.get(0));
+        Offer offer2 = createOffer(2, "offer2", null, centers.get(1));
+        Offer offer3 = createOffer(1, "offer3", null, centers.get(2));
         // when
         List<OfferDetailDto> actual = OfferDetailDto.fromEntityList(List.of(offer1, offer2, offer3));
         // then
@@ -80,11 +81,11 @@ class OfferDetailDtoTest {
                 );
     }
 
-    private Offer createOffer(int price, String contents, Center center) {
+    private Offer createOffer(int price, String contents, Post post, Center center) {
         Offer offer = Offer.builder()
                 .price(price)
                 .contents(contents)
-                .post(null)
+                .post(post)
                 .center(center).build();
         return offerRepository.save(offer);
     }

--- a/33ma3/src/test/java/softeer/be33ma3/dto/response/OfferDetailDtoTest.java
+++ b/33ma3/src/test/java/softeer/be33ma3/dto/response/OfferDetailDtoTest.java
@@ -1,0 +1,91 @@
+package softeer.be33ma3.dto.response;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import softeer.be33ma3.domain.Center;
+import softeer.be33ma3.domain.Member;
+import softeer.be33ma3.domain.Offer;
+import softeer.be33ma3.repository.CenterRepository;
+import softeer.be33ma3.repository.MemberRepository;
+import softeer.be33ma3.repository.OfferRepository;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.tuple;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class OfferDetailDtoTest {
+
+    @Autowired
+    private OfferRepository offerRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private CenterRepository centerRepository;
+
+    @AfterEach
+    void tearDown() {
+        offerRepository.deleteAllInBatch();
+        centerRepository.deleteAllInBatch();
+        memberRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("Offer Entity 객체의 필드를 이용하여 OfferDetailDto로 변환한다.")
+    @Test
+    void fromEntity() {
+        // given
+        Member member = Member.createMember(2, "center1Id", "center1Pw");
+        Member savedMember = memberRepository.save(member);
+        Center center = Center.createCenter("center1", 0.0, 0.0, savedMember);
+        Center savedCenter = centerRepository.save(center);
+        Offer savedOffer = createOffer(10, "offer1", savedCenter);
+        // when
+        OfferDetailDto actual = OfferDetailDto.fromEntity(savedOffer);
+        // then
+        assertThat(actual).extracting("offerId", "memberId", "centerName", "price", "contents", "selected")
+                .containsExactly(savedOffer.getOfferId(), savedMember.getMemberId(), savedCenter.getCenterName(),
+                        savedOffer.getPrice(), savedOffer.getContents(), savedOffer.isSelected());
+    }
+
+    @DisplayName("Offer Entity 목록을 받아 이를 OfferDetailDto 목록으로 변환하고 저렴한 순으로 정렬하여 반환한다.")
+    @Test
+    void fromEntityList() {
+        // given
+        Member member1 = Member.createMember(2, "center1Id", "center1Pw");
+        Member member2 = Member.createMember(2, "center2Id", "center2Pw");
+        Member member3 = Member.createMember(2, "center3Id", "center3Pw");
+        List<Member> members = memberRepository.saveAll(List.of(member1, member2, member3));
+        Center center1 = Center.createCenter("center1", 0.0, 0.0, members.get(0));
+        Center center2 = Center.createCenter("center2", 0.0, 0.0, members.get(1));
+        Center center3 = Center.createCenter("center3", 0.0, 0.0, members.get(2));
+        List<Center> centers = centerRepository.saveAll(List.of(center1, center2, center3));
+        Offer offer1 = createOffer(3, "offer1", centers.get(0));
+        Offer offer2 = createOffer(2, "offer2", centers.get(1));
+        Offer offer3 = createOffer(1, "offer3", centers.get(2));
+        // when
+        List<OfferDetailDto> actual = OfferDetailDto.fromEntityList(List.of(offer1, offer2, offer3));
+        // then
+        assertThat(actual).hasSize(3)
+                .extracting("offerId", "price")
+                .containsExactly(
+                        tuple(offer3.getOfferId(), offer3.getPrice()),
+                        tuple(offer2.getOfferId(), offer2.getPrice()),
+                        tuple(offer1.getOfferId(), offer1.getPrice())
+                );
+    }
+
+    private Offer createOffer(int price, String contents, Center center) {
+        Offer offer = Offer.builder()
+                .price(price)
+                .contents(contents)
+                .post(null)
+                .center(center).build();
+        return offerRepository.save(offer);
+    }
+}

--- a/33ma3/src/test/java/softeer/be33ma3/jwt/JwtServiceTest.java
+++ b/33ma3/src/test/java/softeer/be33ma3/jwt/JwtServiceTest.java
@@ -10,7 +10,7 @@ import org.springframework.test.context.ActiveProfiles;
 import softeer.be33ma3.domain.Member;
 import softeer.be33ma3.dto.request.LoginDto;
 import softeer.be33ma3.dto.response.LoginSuccessDto;
-import softeer.be33ma3.exception.JwtTokenException;
+import softeer.be33ma3.exception.BusinessException;
 import softeer.be33ma3.repository.MemberRepository;
 import softeer.be33ma3.service.MemberService;
 
@@ -60,7 +60,6 @@ class JwtServiceTest {
 
         //when //then
         assertThatThrownBy(() -> jwtService.reissue(refreshToken))
-                .isInstanceOf(JwtTokenException.class)
-                .hasMessage("올바르지 않은 리프레시 토큰");
+                .isInstanceOf(BusinessException.class);
     }
 }

--- a/33ma3/src/test/java/softeer/be33ma3/repository/OfferRepositoryTest.java
+++ b/33ma3/src/test/java/softeer/be33ma3/repository/OfferRepositoryTest.java
@@ -44,10 +44,9 @@ class OfferRepositoryTest {
         Post post1 = Post.createPost(postCreateDto, null, null);
         Post savedPost1 = postRepository.save(post1);
             // offer 저장
-        Offer offer1 = createOffer(1, "offer1", savedPost1, null);
-        Offer offer2 = createOffer(2, "offer2", savedPost1, null);
-        Offer offer3 = createOffer(3, "offer3", savedPost1, null);
-        offerRepository.saveAll(List.of(offer1, offer2, offer3));
+        createOffer(1, "offer1", savedPost1, null);
+        createOffer(2, "offer2", savedPost1, null);
+        createOffer(3, "offer3", savedPost1, null);
         // when
         List<Offer> offerList = offerRepository.findByPost_PostId(savedPost1.getPostId());
         // then
@@ -84,8 +83,7 @@ class OfferRepositoryTest {
         Center center1 = Center.createCenter("서비스센터1", 0, 0, null);
         Center savedCenter1 = centerRepository.save(center1);
             // offer 저장
-        Offer offer1 = createOffer(1, "offer1", savedPost1, savedCenter1);
-        offerRepository.save(offer1);
+        createOffer(1, "offer1", savedPost1, savedCenter1);
         // when
         Optional<Offer> actual = offerRepository.findByPost_PostIdAndCenter_CenterId(savedPost1.getPostId(), savedCenter1.getCenterId());
         // then
@@ -110,11 +108,12 @@ class OfferRepositoryTest {
         assertThat(actual).isEmpty();
     }
 
-    static Offer createOffer(int price, String contents, Post post, Center center) {
-        return Offer.builder()
+    private Offer createOffer(int price, String contents, Post post, Center center) {
+        Offer offer = Offer.builder()
                 .price(price)
                 .contents(contents)
                 .post(post)
                 .center(center).build();
+        return offerRepository.save(offer);
     }
 }

--- a/33ma3/src/test/java/softeer/be33ma3/repository/OfferRepositoryTest.java
+++ b/33ma3/src/test/java/softeer/be33ma3/repository/OfferRepositoryTest.java
@@ -14,7 +14,6 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.tuple;
 
 @ActiveProfiles("test")
 @SpringBootTest

--- a/33ma3/src/test/java/softeer/be33ma3/repository/OfferRepositoryTest.java
+++ b/33ma3/src/test/java/softeer/be33ma3/repository/OfferRepositoryTest.java
@@ -27,64 +27,91 @@ class OfferRepositoryTest {
     @Autowired
     private CenterRepository centerRepository;
 
-    @BeforeEach
-    void setUp() {
-        // post 저장
-        PostCreateDto postCreateDto = new PostCreateDto("승용차", "제네시스", 3,
-                "서울시 강남구", "기스, 깨짐", "오일 교체, 타이어 교체",
-                new ArrayList<>(), "게시글");
-        Post post1 = Post.createPost(postCreateDto, null, null);
-        Post post2 = Post.createPost(postCreateDto, null, null);
-        Post savedPost1 = postRepository.save(post1);
-        Post savedPost2 = postRepository.save(post2);
-        // center 저장
-        Center center1 = Center.createCenter("서비스센터1", 0, 0, null);
-        Center center2 = Center.createCenter("서비스센터2", 0, 0, null);
-        Center center3 = Center.createCenter("서비스센터3", 0, 0, null);
-        Center savedCenter1 = centerRepository.save(center1);
-        Center savedCenter2 = centerRepository.save(center2);
-        Center savedCenter3 = centerRepository.save(center3);
-
-        // offer 저장
-        Offer offer1 = createOffer(1, "offer1", savedPost1, savedCenter1);
-        Offer offer2 = createOffer(2, "offer2", savedPost1, savedCenter2);
-        Offer offer3 = createOffer(3, "offer3", savedPost2, savedCenter3);
-        offerRepository.saveAll(List.of(offer1, offer2, offer3));
-    }
-
     @AfterEach
     void tearDown() {
         offerRepository.deleteAllInBatch();
-        centerRepository.deleteAllInBatch();
         postRepository.deleteAllInBatch();
+        centerRepository.deleteAllInBatch();
     }
 
     @DisplayName("post id를 이용하여 게시글에 속해있는 모든 댓글 목록을 가져올 수 있다.")
     @Test
     void findByPost_PostId() {
-        // given / when
-        List<Offer> offerList = offerRepository.findByPost_PostId(1L);
+        // given
+            // post 저장
+        PostCreateDto postCreateDto = new PostCreateDto("승용차", "제네시스", 3,
+                "서울시 강남구", "기스, 깨짐", "오일 교체, 타이어 교체",
+                new ArrayList<>(), "게시글");
+        Post post1 = Post.createPost(postCreateDto, null, null);
+        Post savedPost1 = postRepository.save(post1);
+            // offer 저장
+        Offer offer1 = createOffer(1, "offer1", savedPost1, null);
+        Offer offer2 = createOffer(2, "offer2", savedPost1, null);
+        Offer offer3 = createOffer(3, "offer3", savedPost1, null);
+        offerRepository.saveAll(List.of(offer1, offer2, offer3));
+        // when
+        List<Offer> offerList = offerRepository.findByPost_PostId(savedPost1.getPostId());
         // then
-        assertThat(offerList).hasSize(2)
-                .extracting("price", "contents")
-                .contains(
-                        tuple(1, "offer1"),
-                        tuple(2, "offer2")
-                );
+        assertThat(offerList).hasSize(3);
+    }
+
+    @DisplayName("댓글이 하나도 달리지 않은 게시글의 댓글 목록을 가져올 경우 빈 배열이 반환된다.")
+    @Test
+    void findByPost_PostId_WithNoOffers() {
+        // given
+        // post 저장
+        PostCreateDto postCreateDto = new PostCreateDto("승용차", "제네시스", 3,
+                "서울시 강남구", "기스, 깨짐", "오일 교체, 타이어 교체",
+                new ArrayList<>(), "게시글");
+        Post post1 = Post.createPost(postCreateDto, null, null);
+        Post savedPost1 = postRepository.save(post1);
+        // when
+        List<Offer> offerList = offerRepository.findByPost_PostId(savedPost1.getPostId());
+        // then
+        assertThat(offerList).hasSize(0);
     }
 
     @DisplayName("해당 게시글에서 해당하는 서비스 센터가 작성한 댓글을 반환할 수 있다.")
     @Test
     void findByPost_PostIdAndCenter_CenterId() {
-        // given / when
-        Optional<Offer> actual = offerRepository.findByPost_PostIdAndCenter_CenterId(1L, 1L);
+        // given
+            // post 저장
+        PostCreateDto postCreateDto = new PostCreateDto("승용차", "제네시스", 3,
+                "서울시 강남구", "기스, 깨짐", "오일 교체, 타이어 교체",
+                new ArrayList<>(), "게시글");
+        Post post1 = Post.createPost(postCreateDto, null, null);
+        Post savedPost1 = postRepository.save(post1);
+            // center 저장
+        Center center1 = Center.createCenter("서비스센터1", 0, 0, null);
+        Center savedCenter1 = centerRepository.save(center1);
+            // offer 저장
+        Offer offer1 = createOffer(1, "offer1", savedPost1, savedCenter1);
+        offerRepository.save(offer1);
+        // when
+        Optional<Offer> actual = offerRepository.findByPost_PostIdAndCenter_CenterId(savedPost1.getPostId(), savedCenter1.getCenterId());
         // then
         assertThat(actual).isPresent()
                         .get().extracting("price", "contents")
                         .containsExactly(1, "offer1");
     }
 
-    Offer createOffer(int price, String contents, Post post, Center center) {
+    @DisplayName("게시글에 견적을 작성하지 않은 서비스 센터일 경우 찾고자 하는 견적이 null로 반환된다.")
+    @Test
+    void findByPost_PostIdAndCenter_CenterId_WithNoOffer() {
+        // given
+        // post 저장
+        PostCreateDto postCreateDto = new PostCreateDto("승용차", "제네시스", 3,
+                "서울시 강남구", "기스, 깨짐", "오일 교체, 타이어 교체",
+                new ArrayList<>(), "게시글");
+        Post post1 = Post.createPost(postCreateDto, null, null);
+        Post savedPost1 = postRepository.save(post1);
+        // when
+        Optional<Offer> actual = offerRepository.findByPost_PostIdAndCenter_CenterId(savedPost1.getPostId(), 1L);
+        // then
+        assertThat(actual).isEmpty();
+    }
+
+    static Offer createOffer(int price, String contents, Post post, Center center) {
         return Offer.builder()
                 .price(price)
                 .contents(contents)

--- a/33ma3/src/test/java/softeer/be33ma3/service/OfferServiceTest.java
+++ b/33ma3/src/test/java/softeer/be33ma3/service/OfferServiceTest.java
@@ -273,8 +273,54 @@ class OfferServiceTest {
         assertThat(exception.getMessage()).isEqualTo("기존 금액보다 낮은 금액으로만 수정 가능합니다.");
     }
 
+    @DisplayName("성공적으로 댓글을 삭제할 수 있다.")
     @Test
     void deleteOffer() {
+        // given
+        // post 저장
+        Post savedPost = createAndSavePost("승용차", "제네시스", 3, "서울시 강남구",
+                "기스, 깨짐", "오일 교체", new ArrayList<>(),"게시글 내용", null, null);
+        // center 저장
+        Member member = Member.createMember(2, "center1Id", "center1Pw");
+        Member savedMember = memberRepository.save(member);
+        Center center = Center.createCenter("center1", 0.0, 0.0, savedMember);
+        centerRepository.save(center);
+        // offer 저장
+        OfferCreateDto offerCreateDto = new OfferCreateDto(10, "offer1");
+        Long offerId = offerService.createOffer(savedPost.getPostId(), offerCreateDto, savedMember);
+        // when
+        offerService.deleteOffer(savedPost.getPostId(), offerId, savedMember);
+        // then
+        Optional<Offer> actual = offerRepository.findById(offerId);
+        assertThat(actual).isEmpty();
+    }
+
+    @DisplayName("댓글 작성자가 아닌 다른 유저의 댓글 삭제 요청시 예외가 발생한다.")
+    @Test
+    void deleteOfferWithNotWriter() {
+        // given
+        // post 저장
+        Post savedPost = createAndSavePost("승용차", "제네시스", 3, "서울시 강남구",
+                "기스, 깨짐", "오일 교체", new ArrayList<>(),"게시글 내용", null, null);
+        // center 저장
+        Member member = Member.createMember(2, "center1Id", "center1Pw");
+        Member savedMember = memberRepository.save(member);
+        Center center = Center.createCenter("center1", 0.0, 0.0, savedMember);
+        centerRepository.save(center);
+        // offer 저장
+        OfferCreateDto offerCreateDto = new OfferCreateDto(10, "offer1");
+        Long offerId = offerService.createOffer(savedPost.getPostId(), offerCreateDto, savedMember);
+        // 새로운 center 생성
+        Member member2 = Member.createMember(2, "center2Id", "center2Pw");
+        Member savedMember2 = memberRepository.save(member2);
+        Center center2 = Center.createCenter("center2", 0.0, 0.0, savedMember2);
+        centerRepository.save(center2);
+        // when
+        UnauthorizedException exception = assertThrows(UnauthorizedException.class, () -> {
+            offerService.deleteOffer(savedPost.getPostId(), offerId, savedMember2);
+        });
+        // then
+        assertThat(exception.getMessage()).isEqualTo("작성자만 삭제 가능합니다.");
     }
 
     @Test

--- a/33ma3/src/test/java/softeer/be33ma3/service/OfferServiceTest.java
+++ b/33ma3/src/test/java/softeer/be33ma3/service/OfferServiceTest.java
@@ -1,0 +1,133 @@
+package softeer.be33ma3.service;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import softeer.be33ma3.domain.Center;
+import softeer.be33ma3.domain.Member;
+import softeer.be33ma3.domain.Offer;
+import softeer.be33ma3.domain.Post;
+import softeer.be33ma3.dto.request.PostCreateDto;
+import softeer.be33ma3.dto.response.OfferDetailDto;
+import softeer.be33ma3.repository.CenterRepository;
+import softeer.be33ma3.repository.MemberRepository;
+import softeer.be33ma3.repository.OfferRepository;
+import softeer.be33ma3.repository.PostRepository;
+
+import java.util.ArrayList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class OfferServiceTest {
+
+    @Autowired private OfferService offerService;
+    @Autowired private OfferRepository offerRepository;
+    @Autowired private PostRepository postRepository;
+    @Autowired private MemberRepository memberRepository;
+    @Autowired private CenterRepository centerRepository;
+
+    @AfterEach
+    void tearDown() {
+        offerRepository.deleteAllInBatch();
+        postRepository.deleteAllInBatch();
+        centerRepository.deleteAllInBatch();
+        memberRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("성공적으로 해당 견적 제시 댓글을 가져와 반환한다.")
+    @Test
+    void showOffer() {
+        // given
+        // post 저장하기
+        PostCreateDto postCreateDto = new PostCreateDto("승용차", "제네시스", 3, "서울시 강남구",
+                "기스, 깨짐", "오일 교체", new ArrayList<>(),"게시글 내용");
+        Post post = Post.createPost(postCreateDto, null, null);
+        Post savedPost = postRepository.save(post);
+        // offer 저장하기
+        Member member = Member.createMember(2, "center1Id", "center1Pw");
+        Member savedMember = memberRepository.save(member);
+        Center center = Center.createCenter("center1", 0.0, 0.0, savedMember);
+        Center savedCenter = centerRepository.save(center);
+        Offer savedOffer = createAndSaveOffer(1, "offer1", savedPost, savedCenter);
+        // when
+        OfferDetailDto actual = offerService.showOffer(savedPost.getPostId(), savedOffer.getOfferId());
+        // then
+        assertThat(actual).extracting("offerId", "price", "centerName", "contents")
+                .containsExactly(savedOffer.getOfferId(), savedOffer.getPrice(), savedCenter.getCenterName(), savedOffer.getContents());
+    }
+
+    @DisplayName("존재하지 않는 게시글에 대한 견적 댓글 조회 요청일 경우 예외가 발생한다.")
+    @Test
+    void showOfferWithNoPost() {
+        // given
+        // when
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            offerService.showOffer(1L, 1L);
+        });
+        // then
+        assertThat(exception.getMessage()).isEqualTo("존재하지 않는 게시글");
+    }
+
+    @DisplayName("존재하지 않는 댓글에 대한 조회 요청일 경우 예외가 발생한다.")
+    @Test
+    void showOfferWithNoOffer() {
+        // given
+        PostCreateDto postCreateDto = new PostCreateDto("승용차", "제네시스", 3, "서울시 강남구",
+                "기스, 깨짐", "오일 교체", new ArrayList<>(),"게시글 내용");
+        Post post = Post.createPost(postCreateDto, null, null);
+        Post savedPost = postRepository.save(post);
+        // when
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            offerService.showOffer(savedPost.getPostId(), 1L);
+        });
+        // then
+        assertThat(exception.getMessage()).isEqualTo("존재하지 않는 견적");
+    }
+
+    @Test
+    void createOffer() {
+    }
+
+    @Test
+    void updateOffer() {
+    }
+
+    @Test
+    void deleteOffer() {
+    }
+
+    @Test
+    void selectOffer() {
+    }
+
+    @Test
+    void calculateAvgPrice() {
+    }
+
+    @Test
+    void sendAboutOfferUpdate() {
+    }
+
+    @Test
+    void sendOfferList2Writer() {
+    }
+
+    @Test
+    void sendAvgPrice2Others() {
+    }
+
+    private Offer createAndSaveOffer(int price, String contents, Post post, Center center) {
+        Offer offer = Offer.builder()
+                .price(price)
+                .contents(contents)
+                .post(post)
+                .center(center).build();
+        return offerRepository.save(offer);
+    }
+}

--- a/33ma3/src/test/java/softeer/be33ma3/service/OfferServiceTest.java
+++ b/33ma3/src/test/java/softeer/be33ma3/service/OfferServiceTest.java
@@ -11,7 +11,7 @@ import softeer.be33ma3.domain.*;
 import softeer.be33ma3.dto.request.OfferCreateDto;
 import softeer.be33ma3.dto.request.PostCreateDto;
 import softeer.be33ma3.dto.response.OfferDetailDto;
-import softeer.be33ma3.exception.UnauthorizedException;
+import softeer.be33ma3.exception.BusinessException;
 import softeer.be33ma3.repository.CenterRepository;
 import softeer.be33ma3.repository.MemberRepository;
 import softeer.be33ma3.repository.OfferRepository;
@@ -68,11 +68,11 @@ class OfferServiceTest {
     void showOfferWithNoPost() {
         // given
         // when
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
             offerService.showOffer(999L, 999L);
         });
         // then
-        assertThat(exception.getMessage()).isEqualTo("존재하지 않는 게시글");
+        assertThat(exception.getErrorCode().getErrorMessage()).isEqualTo("존재하지 않는 게시글");
     }
 
     @DisplayName("존재하지 않는 댓글에 대한 조회 요청일 경우 예외가 발생한다.")
@@ -82,11 +82,11 @@ class OfferServiceTest {
         Post savedPost = createAndSavePost("승용차", "제네시스", 3, "서울시 강남구",
                 "기스, 깨짐", "오일 교체", new ArrayList<>(),"게시글 내용", null, null);
         // when
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
             offerService.showOffer(savedPost.getPostId(), 999L);
         });
         // then
-        assertThat(exception.getMessage()).isEqualTo("존재하지 않는 견적");
+        assertThat(exception.getErrorCode().getErrorMessage()).isEqualTo("존재하지 않는 견적");
     }
 
     @DisplayName("성공적으로 견적 댓글을 생성할 수 있다.")
@@ -116,11 +116,11 @@ class OfferServiceTest {
     void createOfferWithNoPost() {
         // given
         // when
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
             offerService.createOffer(1L, null, null);
         });
         // then
-        assertThat(exception.getMessage()).isEqualTo("존재하지 않는 게시글");
+        assertThat(exception.getErrorCode().getErrorMessage()).isEqualTo("존재하지 않는 게시글");
     }
 
     @DisplayName("경매 완료된 게시글에 대해 댓글 생성 요청시 예외가 발생한다.")
@@ -133,11 +133,11 @@ class OfferServiceTest {
         savedPost.setDone();
         postRepository.save(savedPost);
         // when
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
             offerService.createOffer(savedPost.getPostId(), null, null);
         });
         // then
-        assertThat(exception.getMessage()).isEqualTo("완료된 게시글");
+        assertThat(exception.getErrorCode().getErrorMessage()).isEqualTo("마감된 게시글");
     }
 
     @DisplayName("존재하지 않는 센터로 댓글 생성 요청시 예외가 발생한다.")
@@ -149,11 +149,11 @@ class OfferServiceTest {
         Member member = Member.createMember(2, "center1Id", "center1Pw");
         Member savedMember = memberRepository.save(member);
         // when
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
             offerService.createOffer(savedPost.getPostId(), null, savedMember);
         });
         // then
-        assertThat(exception.getMessage()).isEqualTo("존재하지 않는 센터");
+        assertThat(exception.getErrorCode().getErrorMessage()).isEqualTo("존재하지 않는 센터");
     }
 
     @DisplayName("이미 견적을 제시한 서비스 센터가 댓글 생성 요청시 예외가 발생한다.")
@@ -170,11 +170,11 @@ class OfferServiceTest {
         // 새로운 견적 제시 dto 생성하기
         OfferCreateDto offerCreateDto = new OfferCreateDto(1, "offer2");
         // when
-        UnauthorizedException exception = assertThrows(UnauthorizedException.class, () -> {
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
             offerService.createOffer(savedPost.getPostId(), offerCreateDto, savedMember);
         });
         // then
-        assertThat(exception.getMessage()).isEqualTo("이미 견적을 작성하였습니다.");
+        assertThat(exception.getErrorCode().getErrorMessage()).isEqualTo("이미 견적을 작성하였습니다.");
     }
 
     @DisplayName("성공적으로 댓글을 수정할 수 있다.")
@@ -220,11 +220,11 @@ class OfferServiceTest {
         Long offerId = offerService.createOffer(savedPost.getPostId(), offerCreateDto, savedMember);
         OfferCreateDto offerCreateDto2 = new OfferCreateDto(9, "new offer1");
         // when
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
             offerService.updateOffer(savedPost2.getPostId(), offerId, offerCreateDto2, savedMember);
         });
         // then
-        assertThat(exception.getMessage()).isEqualTo("존재하지 않는 견적");
+        assertThat(exception.getErrorCode().getErrorMessage()).isEqualTo("존재하지 않는 견적");
     }
 
     @DisplayName("댓글 작성자가 아닌 다른 유저가 댓글 수정 요청시 예외가 발생한다.")
@@ -248,11 +248,11 @@ class OfferServiceTest {
         Center center2 = Center.createCenter("center2", 0.0, 0.0, savedMember2);
         centerRepository.save(center2);
         // when
-        UnauthorizedException exception = assertThrows(UnauthorizedException.class, () -> {
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
             offerService.updateOffer(savedPost.getPostId(), offerId, null, savedMember2);
         });
         // then
-        assertThat(exception.getMessage()).isEqualTo("작성자만 수정 가능합니다.");
+        assertThat(exception.getErrorCode().getErrorMessage()).isEqualTo("작성자만 가능합니다.");
     }
 
     @DisplayName("기존보다 더 높은 가격으로 수정 요청시 예외가 발생한다.")
@@ -272,11 +272,11 @@ class OfferServiceTest {
         Long offerId = offerService.createOffer(savedPost.getPostId(), offerCreateDto, savedMember);
         OfferCreateDto offerCreateDto2 = new OfferCreateDto(11, "new offer1");
         // when
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
             offerService.updateOffer(savedPost.getPostId(), offerId, offerCreateDto2, savedMember);
         });
         // then
-        assertThat(exception.getMessage()).isEqualTo("기존 금액보다 낮은 금액으로만 수정 가능합니다.");
+        assertThat(exception.getErrorCode().getErrorMessage()).isEqualTo("기존 금액보다 낮은 금액으로만 수정 가능합니다.");
     }
 
     @DisplayName("성공적으로 댓글을 삭제할 수 있다.")
@@ -322,11 +322,11 @@ class OfferServiceTest {
         Center center2 = Center.createCenter("center2", 0.0, 0.0, savedMember2);
         centerRepository.save(center2);
         // when
-        UnauthorizedException exception = assertThrows(UnauthorizedException.class, () -> {
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
             offerService.deleteOffer(savedPost.getPostId(), offerId, savedMember2);
         });
         // then
-        assertThat(exception.getMessage()).isEqualTo("작성자만 삭제 가능합니다.");
+        assertThat(exception.getErrorCode().getErrorMessage()).isEqualTo("작성자만 가능합니다.");
     }
 
     @DisplayName("성공적으로 댓글을 낙찰할 수 있다.")
@@ -375,11 +375,11 @@ class OfferServiceTest {
         OfferCreateDto offerCreateDto = new OfferCreateDto(10, "offer1");
         Long offerId = offerService.createOffer(savedPost.getPostId(), offerCreateDto, savedMember);
         // when
-        UnauthorizedException exception = assertThrows(UnauthorizedException.class, () -> {
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
             offerService.selectOffer(savedPost.getPostId(), offerId, savedMember);
         });
         // then
-        assertThat(exception.getMessage()).isEqualTo("작성자만 낙찰 가능합니다.");
+        assertThat(exception.getErrorCode().getErrorMessage()).isEqualTo("작성자만 가능합니다.");
     }
 
     @DisplayName("댓글의 평균 제시 가격을 계산하고 소수 첫째자리까지 나타낸다.")

--- a/33ma3/src/test/java/softeer/be33ma3/service/OfferServiceTest.java
+++ b/33ma3/src/test/java/softeer/be33ma3/service/OfferServiceTest.java
@@ -382,20 +382,18 @@ class OfferServiceTest {
         assertThat(exception.getMessage()).isEqualTo("작성자만 낙찰 가능합니다.");
     }
 
+    @DisplayName("댓글의 평균 제시 가격을 계산하고 소수 첫째자리까지 나타낸다.")
     @Test
     void calculateAvgPrice() {
-    }
-
-    @Test
-    void sendAboutOfferUpdate() {
-    }
-
-    @Test
-    void sendOfferList2Writer() {
-    }
-
-    @Test
-    void sendAvgPrice2Others() {
+        // given
+        Offer offer1 = createAndSaveOffer(5, "offer1", null, null);
+        Offer offer2 = createAndSaveOffer(6, "offer2", null, null);
+        Offer offer3 = createAndSaveOffer(7, "offer3", null, null);
+        Offer offer4 = createAndSaveOffer(5, "offer4", null, null);
+        // when
+        double avgPrice = OfferService.calculateAvgPrice(List.of(offer1, offer2, offer3, offer4));
+        // then
+        assertThat(avgPrice).isEqualTo(5.8);
     }
 
     private Offer createAndSaveOffer(int price, String contents, Post post, Center center) {

--- a/33ma3/src/test/java/softeer/be33ma3/service/PostServiceTest.java
+++ b/33ma3/src/test/java/softeer/be33ma3/service/PostServiceTest.java
@@ -11,6 +11,7 @@ import softeer.be33ma3.domain.Member;
 import softeer.be33ma3.domain.Post;
 import softeer.be33ma3.domain.Region;
 import softeer.be33ma3.dto.request.PostCreateDto;
+import softeer.be33ma3.exception.BusinessException;
 import softeer.be33ma3.repository.MemberRepository;
 import softeer.be33ma3.repository.PostRepository;
 import softeer.be33ma3.repository.RegionRepository;
@@ -78,8 +79,7 @@ class PostServiceTest {
 
         //when //then
         assertThatThrownBy(() -> postService.editPost(member2, savedPost.getPostId(), postEditDto))
-                .isInstanceOf(UnauthorizedException.class)
-                .hasMessage("작성자만 가능합니다.");
+                .isInstanceOf(BusinessException.class);
     }
 
     private Post savePost(Region region, Member member1) {


### PR DESCRIPTION
## 구현 내용
- [x] offerDetailDto, OfferRepository, OfferService 테스트 코드 작성
- [x] 평균 견적 제시 가격 계산 메소드 수정
- [x] 웹소켓 통신 관련 로그 추가

## 고민 사항
웹소켓 통신이 원활하게 이루어지지 않고 어딘가에서 문제가 발생해서, 통신을 통해 데이터를 주고 받는 과정에서 로그를 찍어 확인할 수 있도록 하였다.
평균 제시가 계산 메소드의 경우 기존에는 stats을 전부 계산하는 내장 함수를 사용하였으나, 우리는 오직 합계만 필요하므로 간결하고 명확한 코드를 위해 합계만을 계산하여 평균을 반환하는 방식으로 수정하였다.

## 기타
