### PR TITLE
문의 목록 실시간 전송 기능 구현 #106

### DIFF
--- a/33ma3/src/main/java/softeer/be33ma3/controller/ChatController.java
+++ b/33ma3/src/main/java/softeer/be33ma3/controller/ChatController.java
@@ -73,7 +73,7 @@ public class ChatController {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "채팅 내역 전송 성공", content = @Content(schema = @Schema(implementation = DataResponse.class))),
             @ApiResponse(responseCode = "401", description = "해당 방의 회원이 아닙니다.", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
-            @ApiResponse(responseCode = "400", description = "존재하지 않는 채팅 룸", content = @Content(schema = @Schema(implementation = SingleResponse.class)))
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 채팅 룸", content = @Content(schema = @Schema(implementation = SingleResponse.class)))
     })
     @Operation(summary = "채팅 내역 조회", description = "채팅 내역을 조회하는 메서드 입니다.")
     @GetMapping("/chat/history/{room_id}")

--- a/33ma3/src/main/java/softeer/be33ma3/controller/ChatController.java
+++ b/33ma3/src/main/java/softeer/be33ma3/controller/ChatController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 import softeer.be33ma3.domain.Member;
 import softeer.be33ma3.dto.request.ChatMessageRequestDto;
 import softeer.be33ma3.dto.response.ChatHistoryDto;
-import softeer.be33ma3.dto.response.ChatRoomListDto;
+import softeer.be33ma3.dto.response.AllChatRoomDto;
 import softeer.be33ma3.jwt.CurrentUser;
 import softeer.be33ma3.response.DataResponse;
 import softeer.be33ma3.response.SingleResponse;
@@ -65,9 +65,9 @@ public class ChatController {
     @Operation(summary = "문의 내역", description = "문의 내역 보기 메서드 입니다.")
     @GetMapping("/chatRoom/all")
     public ResponseEntity<?> showAllChatRoom(@Schema(hidden = true) @CurrentUser Member member){
-        List<ChatRoomListDto> allChatRoomListDto = chatService.showAllChatRoom(member);
+        List<AllChatRoomDto> allAllChatRoomDtos = chatService.showAllChatRoom(member);
 
-        return ResponseEntity.ok().body(DataResponse.success("문의 내역 전송 성공", allChatRoomListDto));
+        return ResponseEntity.ok().body(DataResponse.success("문의 내역 전송 성공", allAllChatRoomDtos));
     }
 
     @ApiResponses({

--- a/33ma3/src/main/java/softeer/be33ma3/controller/ChatController.java
+++ b/33ma3/src/main/java/softeer/be33ma3/controller/ChatController.java
@@ -76,8 +76,8 @@ public class ChatController {
             @ApiResponse(responseCode = "400", description = "존재하지 않는 채팅 룸", content = @Content(schema = @Schema(implementation = SingleResponse.class)))
     })
     @Operation(summary = "채팅 내역 조회", description = "채팅 내역을 조회하는 메서드 입니다.")
-    @GetMapping("/chat/history/{roomId}")
-    public ResponseEntity<?> showOneChatHistory(@Schema(hidden = true) @CurrentUser Member member, @PathVariable("roomId") Long roomId){
+    @GetMapping("/chat/history/{room_id}")
+    public ResponseEntity<?> showOneChatHistory(@Schema(hidden = true) @CurrentUser Member member, @PathVariable("room_id") Long roomId){
          List<ChatHistoryDto> chatHistoryDtos = chatService.showOneChatHistory(member, roomId);
 
         return ResponseEntity.ok().body(DataResponse.success("채팅 내역 전송 성공", chatHistoryDtos));

--- a/33ma3/src/main/java/softeer/be33ma3/controller/ChatController.java
+++ b/33ma3/src/main/java/softeer/be33ma3/controller/ChatController.java
@@ -65,9 +65,9 @@ public class ChatController {
     @Operation(summary = "문의 내역", description = "문의 내역 보기 메서드 입니다.")
     @GetMapping("/chatRoom/all")
     public ResponseEntity<?> showAllChatRoom(@Schema(hidden = true) @CurrentUser Member member){
-        List<AllChatRoomDto> allAllChatRoomDtos = chatService.showAllChatRoom(member);
+        List<AllChatRoomDto> allChatRoomDtos = chatService.showAllChatRoom(member);
 
-        return ResponseEntity.ok().body(DataResponse.success("문의 내역 전송 성공", allAllChatRoomDtos));
+        return ResponseEntity.ok().body(DataResponse.success("문의 내역 전송 성공", allChatRoomDtos));
     }
 
     @ApiResponses({

--- a/33ma3/src/main/java/softeer/be33ma3/controller/PostController.java
+++ b/33ma3/src/main/java/softeer/be33ma3/controller/PostController.java
@@ -56,7 +56,7 @@ public class PostController {
     })
     @Operation(summary = "게시글 작성", description = "게시글 작성 메서드 입니다.")
     @PostMapping(value = "/create", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE})
-    public ResponseEntity<?> createPost(@Schema(hidden = true) @CurrentUser Member member, @RequestPart(name = "images") List<MultipartFile> images, @RequestPart(name = "request") PostCreateDto postCreateDto){
+    public ResponseEntity<?> createPost(@Schema(hidden = true) @CurrentUser Member member, @RequestPart(name = "images", required = false) List<MultipartFile> images, @RequestPart(name = "request") PostCreateDto postCreateDto){
         Long postId = postService.createPost(member,postCreateDto, images);
 
         return ResponseEntity.ok().body(DataResponse.success("게시글 작성 성공", postId));

--- a/33ma3/src/main/java/softeer/be33ma3/domain/Review.java
+++ b/33ma3/src/main/java/softeer/be33ma3/domain/Review.java
@@ -19,6 +19,10 @@ public class Review {
     private Post post;
 
     @ManyToOne
-    @JoinColumn(name = "member_id")
-    private Member member;
+    @JoinColumn(name = "writer_id")
+    private Member writer;
+
+    @ManyToOne
+    @JoinColumn(name = "center_id")
+    private Center center;
 }

--- a/33ma3/src/main/java/softeer/be33ma3/dto/response/AllChatRoomDto.java
+++ b/33ma3/src/main/java/softeer/be33ma3/dto/response/AllChatRoomDto.java
@@ -19,8 +19,10 @@ public class AllChatRoomDto {
     private String lastMessage;     // 마지막 메세지
     @Schema(description = "읽지 않은 메세지 개수", example = "5")
     private int noReadCount;        // 읽지 않은 메세지 개수
+    @Schema(description = "메세지 생성 시간", example = "오전 07:12")
+    private String createTime;
 
-    public static AllChatRoomDto create(ChatRoom chatRoom, String lastMessage, String memberName, int noReadCount) {
+    public static AllChatRoomDto create(ChatRoom chatRoom, String lastMessage, String memberName, int noReadCount, String createTime) {
         AllChatRoomDto allChatRoomDto = new AllChatRoomDto();
         allChatRoomDto.roomId = chatRoom.getChatRoomId();
         allChatRoomDto.centerId = chatRoom.getCenter().getMemberId();
@@ -28,6 +30,7 @@ public class AllChatRoomDto {
         allChatRoomDto.memberName = memberName;
         allChatRoomDto.lastMessage = lastMessage;
         allChatRoomDto.noReadCount = noReadCount;
+        allChatRoomDto.createTime = createTime;
 
         return allChatRoomDto;
     }

--- a/33ma3/src/main/java/softeer/be33ma3/dto/response/AllChatRoomDto.java
+++ b/33ma3/src/main/java/softeer/be33ma3/dto/response/AllChatRoomDto.java
@@ -6,7 +6,7 @@ import softeer.be33ma3.domain.ChatRoom;
 
 @Data
 @Schema(description = "문의 내역 리스트 응답")
-public class ChatRoomListDto {
+public class AllChatRoomDto {
     @Schema(description = "방 아이디", example = "1")
     private Long roomId;
     @Schema(description = "센터 아이디", example = "1")
@@ -20,15 +20,15 @@ public class ChatRoomListDto {
     @Schema(description = "읽지 않은 메세지 개수", example = "5")
     private int noReadCount;        // 읽지 않은 메세지 개수
 
-    public static ChatRoomListDto createChatRoomDto(ChatRoom chatRoom, String lastMessage, String memberName, int noReadCount) {
-        ChatRoomListDto chatRoomListDto = new ChatRoomListDto();
-        chatRoomListDto.roomId = chatRoom.getChatRoomId();
-        chatRoomListDto.centerId = chatRoom.getCenter().getMemberId();
-        chatRoomListDto.clientId = chatRoom.getClient().getMemberId();
-        chatRoomListDto.memberName = memberName;
-        chatRoomListDto.lastMessage = lastMessage;
-        chatRoomListDto.noReadCount = noReadCount;
+    public static AllChatRoomDto create(ChatRoom chatRoom, String lastMessage, String memberName, int noReadCount) {
+        AllChatRoomDto allChatRoomDto = new AllChatRoomDto();
+        allChatRoomDto.roomId = chatRoom.getChatRoomId();
+        allChatRoomDto.centerId = chatRoom.getCenter().getMemberId();
+        allChatRoomDto.clientId = chatRoom.getClient().getMemberId();
+        allChatRoomDto.memberName = memberName;
+        allChatRoomDto.lastMessage = lastMessage;
+        allChatRoomDto.noReadCount = noReadCount;
 
-        return chatRoomListDto;
+        return allChatRoomDto;
     }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/dto/response/ChatHistoryDto.java
+++ b/33ma3/src/main/java/softeer/be33ma3/dto/response/ChatHistoryDto.java
@@ -5,9 +5,6 @@ import lombok.Builder;
 import lombok.Data;
 import softeer.be33ma3.domain.ChatMessage;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-
 @Data
 @Builder
 @Schema(description = "채팅 내역")

--- a/33ma3/src/main/java/softeer/be33ma3/dto/response/ChatHistoryDto.java
+++ b/33ma3/src/main/java/softeer/be33ma3/dto/response/ChatHistoryDto.java
@@ -21,19 +21,12 @@ public class ChatHistoryDto {
     @Schema(description = "읽음 여부", example = "1")
     private boolean readDone;
 
-    public static ChatHistoryDto getChatHistoryDto(ChatMessage chatMessage){
+    public static ChatHistoryDto getChatHistoryDto(ChatMessage chatMessage, String createTime){
         return ChatHistoryDto.builder()
                 .senderId(chatMessage.getSender().getMemberId())
                 .contents(chatMessage.getContents())
-                .createTime(createTimeFormatting(chatMessage.getCreateTime()))
+                .createTime(createTime)
                 .readDone(chatMessage.isReadDone())
                 .build();
-    }
-
-    private static String createTimeFormatting(LocalDateTime createTime) {
-        String periodOfDay = createTime.getHour() < 12 ? "오전 " : "오후 ";
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm");
-
-        return periodOfDay + createTime.format(formatter);
     }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/dto/response/ChatMessageResponseDto.java
+++ b/33ma3/src/main/java/softeer/be33ma3/dto/response/ChatMessageResponseDto.java
@@ -13,10 +13,10 @@ import java.time.LocalDateTime;
 public class ChatMessageResponseDto {
     @Schema(description = "내용", example = "문의문의문의합니다")
     private String contents;
-    @Schema(description = "메세지 보낸 시간", example = "2024-02-06T02:23:25.043239")
-    private LocalDateTime createTime;
+    @Schema(description = "메세지 보낸 시간", example = "오전 11:00")
+    private String createTime;
 
-    public static ChatMessageResponseDto create(ChatMessage chatMessage){
-        return new ChatMessageResponseDto(chatMessage.getContents(), chatMessage.getCreateTime());
+    public static ChatMessageResponseDto create(ChatMessage chatMessage, String createTime){
+        return new ChatMessageResponseDto(chatMessage.getContents(), createTime);
     }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/dto/response/ChatMessageResponseDto.java
+++ b/33ma3/src/main/java/softeer/be33ma3/dto/response/ChatMessageResponseDto.java
@@ -5,8 +5,6 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import softeer.be33ma3.domain.ChatMessage;
 
-import java.time.LocalDateTime;
-
 @Data
 @AllArgsConstructor
 @Schema(description = "채팅 메세지 응답")

--- a/33ma3/src/main/java/softeer/be33ma3/dto/response/PostDetailDto.java
+++ b/33ma3/src/main/java/softeer/be33ma3/dto/response/PostDetailDto.java
@@ -5,12 +5,9 @@ import lombok.Builder;
 import lombok.Getter;
 import softeer.be33ma3.domain.Image;
 import softeer.be33ma3.domain.Post;
-import softeer.be33ma3.service.PostService;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.util.Arrays;
 import java.util.List;
 
 @Builder

--- a/33ma3/src/main/java/softeer/be33ma3/dto/response/PostThumbnailDto.java
+++ b/33ma3/src/main/java/softeer/be33ma3/dto/response/PostThumbnailDto.java
@@ -5,7 +5,6 @@ import lombok.Builder;
 import lombok.Getter;
 import softeer.be33ma3.domain.Image;
 import softeer.be33ma3.domain.Post;
-import softeer.be33ma3.service.PostService;
 
 import java.time.Duration;
 import java.time.LocalDateTime;

--- a/33ma3/src/main/java/softeer/be33ma3/dto/response/PostWithAvgPriceDto.java
+++ b/33ma3/src/main/java/softeer/be33ma3/dto/response/PostWithAvgPriceDto.java
@@ -1,7 +1,6 @@
 package softeer.be33ma3.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter

--- a/33ma3/src/main/java/softeer/be33ma3/exception/ControllerAdvice.java
+++ b/33ma3/src/main/java/softeer/be33ma3/exception/ControllerAdvice.java
@@ -1,7 +1,9 @@
 package softeer.be33ma3.exception;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import softeer.be33ma3.response.SingleResponse;
@@ -13,5 +15,10 @@ public class ControllerAdvice {
     @ExceptionHandler(BusinessException.class)
     public ResponseEntity<?> handlerBizException(BusinessException e) {;
         return ResponseEntity.status(e.getErrorCode().getStatus()).body(SingleResponse.error(e.getErrorCode().getErrorMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<?> methodArgumentNotValid(MethodArgumentNotValidException e){
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(SingleResponse.error(e.getFieldError().getDefaultMessage()));
     }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/jwt/JwtProvider.java
+++ b/33ma3/src/main/java/softeer/be33ma3/jwt/JwtProvider.java
@@ -8,7 +8,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import softeer.be33ma3.exception.BusinessException;
-import softeer.be33ma3.repository.MemberRepository;
 
 import java.security.Key;
 import java.util.Date;
@@ -19,13 +18,11 @@ import static softeer.be33ma3.jwt.JwtProperties.*;
 @Slf4j
 @Component //빈으로 등록
 public class JwtProvider {  //jwt 토큰을 만들고 검증하는 역할
-    private final MemberRepository memberRepository;
     private final Key key;
 
-    public JwtProvider(@Value("${jwt.secret}") String secret, MemberRepository memberRepository) {
+    public JwtProvider(@Value("${jwt.secret}") String secret) {
         byte[] keyBytes = Decoders.BASE64.decode(secret);
         this.key = Keys.hmacShaKeyFor(keyBytes);
-        this.memberRepository = memberRepository;
     }
 
     public JwtToken createJwtToken(int memberType, Long memberId, String longinId){

--- a/33ma3/src/main/java/softeer/be33ma3/repository/ChatMessageRepository.java
+++ b/33ma3/src/main/java/softeer/be33ma3/repository/ChatMessageRepository.java
@@ -11,8 +11,8 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
     @Query("SELECT COALESCE(COUNT(c), 0) FROM ChatMessage c WHERE c.chatRoom.chatRoomId = :chatRoomId AND c.readDone = false AND c.sender.memberId != :memberId")
     long countReadDoneIsFalse(@Param("chatRoomId") Long chatRoomId, @Param("memberId") Long memberId);  //내가 아닌 다른 사람이 보낸 경우 읽음이 false 인 개수
 
-    @Query("SELECT c.contents FROM ChatMessage c WHERE c.chatRoom.chatRoomId = :chatRoomId ORDER BY c.createTime DESC LIMIT 1")
-    String findLastMessageByChatRoomId(@Param("chatRoomId") Long chatRoomId);
+    @Query("SELECT c FROM ChatMessage c WHERE c.chatRoom.chatRoomId = :chatRoomId ORDER BY c.createTime DESC LIMIT 1")
+    ChatMessage findLastMessageByChatRoomId(@Param("chatRoomId") Long chatRoomId);
 
     List<ChatMessage> findByChatRoom_ChatRoomId(Long roomId);
 }

--- a/33ma3/src/main/java/softeer/be33ma3/service/ChatService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/ChatService.java
@@ -67,7 +67,7 @@ public class ChatService {
                 alertRepository.save(alert);
                 return;
             }
-            updateAllChatList(receiver, chatRoom);    //실시간 전송 - 채팅 목록
+            updateAllChatRoom(receiver, chatRoom);    //실시간 전송 - 채팅 목록
             return;
         }
         //채팅룸에 상대방이 존재하는 경우
@@ -114,7 +114,7 @@ public class ChatService {
         return chatHistoryDtos;
     }
 
-    private void updateAllChatList(Member receiver, ChatRoom chatRoom) {
+    private void updateAllChatRoom(Member receiver, ChatRoom chatRoom) {
         if(receiver.getMemberId() == CENTER_TYPE){      //받는 사람이 센터인 경우
             Center center = centerRepository.findByMember_MemberId(receiver.getMemberId()).orElseThrow(() -> new BusinessException(NOT_FOUND_CENTER));
             AllChatRoomDto chatDto = getChatDto(chatRoom, center.getCenterName(), receiver);

--- a/33ma3/src/main/java/softeer/be33ma3/service/ChatService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/ChatService.java
@@ -56,7 +56,7 @@ public class ChatService {
     public void sendMessage(Member sender, Long roomId, Long receiverId, String contents) {
         ChatRoom chatRoom = chatRoomRepository.findById(roomId).orElseThrow(() -> new BusinessException(NOT_FOUND_CHAT_ROOM));
         Member receiver = memberRepository.findById(receiverId).orElseThrow(() -> new BusinessException(NOT_FOUND_MEMBER));
-        validateSenderAndReceiver(sender, chatRoom, receiver);      //보내는 사람, 받는 사람이 해당 방의 멤버가 맞는지 검증
+        isValidSenderAndReceiver(sender, chatRoom, receiver);      //보내는 사람, 받는 사람이 해당 방의 멤버가 맞는지 검증
 
         ChatMessage chatMessage = ChatMessage.createChatMessage(sender, chatRoom, contents);
         ChatMessage savedChatMessage = chatMessageRepository.save(chatMessage);
@@ -99,7 +99,7 @@ public class ChatService {
     @Transactional
     public List<ChatHistoryDto> showOneChatHistory(Member member, Long roomId) {
         ChatRoom chatRoom = chatRoomRepository.findById(roomId).orElseThrow(() -> new BusinessException(NOT_FOUND_CHAT_ROOM));
-        validateIsRoomMember(member, chatRoom);
+        isValidRoomMember(member, chatRoom);
 
         List<ChatMessage> chatMessages = chatMessageRepository.findByChatRoom_ChatRoomId(chatRoom.getChatRoomId());
 
@@ -133,7 +133,7 @@ public class ChatService {
         return AllChatRoomDto.create(chatRoom, lastChatMessage.getContents(), memberName, count, createTimeFormatting(lastChatMessage.getCreateTime()));
     }
 
-    private void validateIsRoomMember(Member member, ChatRoom chatRoom) {
+    private void isValidRoomMember(Member member, ChatRoom chatRoom) {
         if (member.getMemberType() == CLIENT_TYPE && !chatRoom.getClient().equals(member)) {
             throw new BusinessException(NOT_A_MEMBER_OF_ROOM);
         }
@@ -143,7 +143,7 @@ public class ChatService {
         }
     }
 
-    private void validateSenderAndReceiver(Member sender, ChatRoom chatRoom, Member receiver) {
+    private void isValidSenderAndReceiver(Member sender, ChatRoom chatRoom, Member receiver) {
         Member client = chatRoom.getClient();
         Member center = chatRoom.getCenter();
 

--- a/33ma3/src/main/java/softeer/be33ma3/service/ChatService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/ChatService.java
@@ -56,7 +56,8 @@ public class ChatService {
         Member receiver = memberRepository.findById(receiverId).orElseThrow(() -> new BusinessException(NOT_FOUND_MEMBER));
 
         if(sender.getMemberType() == CLIENT_TYPE){
-            if(!(chatRoom.getClient().equals(sender) && chatRoom.getCenter().equals(receiver))){
+            if(!(chatRoom.getClient().getMemberId().equals(sender.getMemberId())
+                    && chatRoom.getCenter().getMemberId().equals(receiver.getMemberId()))){
                 throw new BusinessException(NOT_A_MEMBER_OF_ROOM);
             }
         }
@@ -105,7 +106,7 @@ public class ChatService {
 
         List<ChatHistoryDto> chatHistoryDtos = new ArrayList<>();
         for (ChatMessage chatMessage : chatMessages) {
-            if(!chatMessage.getSender().equals(member) && !chatMessage.isReadDone()){   //상대방이 보낸 메세지의 읽음 여부가 false인 경우
+            if(!chatMessage.getSender().getMemberId().equals(member.getMemberId()) && !chatMessage.isReadDone()){   //상대방이 보낸 메세지의 읽음 여부가 false인 경우
                 chatMessage.setReadDoneTrue();      //읽음 처리
             }
             chatHistoryDtos.add(ChatHistoryDto.getChatHistoryDto(chatMessage));
@@ -116,11 +117,11 @@ public class ChatService {
 
     private void validateMember(Member member, ChatRoom chatRoom) {
         if (member.getMemberType() == CLIENT_TYPE && !chatRoom.getClient().equals(member)) {
-            throw new UnauthorizedException("해당 방의 회원이 아닙니다.");
+            throw new BusinessException(NOT_A_MEMBER_OF_ROOM);
         }
 
         if (member.getMemberType() == CENTER_TYPE && !chatRoom.getCenter().equals(member)) {
-            throw new UnauthorizedException("해당 방의 회원이 아닙니다.");
+            throw new BusinessException(NOT_A_MEMBER_OF_ROOM);
         }
     }
 

--- a/33ma3/src/main/java/softeer/be33ma3/service/ChatService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/ChatService.java
@@ -77,23 +77,23 @@ public class ChatService {
     }
 
     public List<AllChatRoomDto> showAllChatRoom(Member member) {
-        List<AllChatRoomDto> allAllChatRoomDto = new ArrayList<>();
+        List<AllChatRoomDto> allChatRoomDto = new ArrayList<>();
 
         if(member.getMemberType() == CLIENT_TYPE){
             List<ChatRoom> chatRooms = chatRoomRepository.findByClient_MemberId(member.getMemberId());
             for (ChatRoom chatRoom : chatRooms) {
                 Center center = centerRepository.findByMember_MemberId(chatRoom.getCenter().getMemberId()).get();
-                allAllChatRoomDto.add(getChatDto(chatRoom, center.getCenterName(), member));
+                allChatRoomDto.add(getChatDto(chatRoom, center.getCenterName(), member));
             }
         }
         if(member.getMemberType() == CENTER_TYPE) {
             List<ChatRoom> chatRooms = chatRoomRepository.findByCenter_MemberId(member.getMemberId());
             for (ChatRoom chatRoom : chatRooms) {
-                allAllChatRoomDto.add(getChatDto(chatRoom, chatRoom.getClient().getLoginId(), member));
+                allChatRoomDto.add(getChatDto(chatRoom, chatRoom.getClient().getLoginId(), member));
             }
         }
 
-        return allAllChatRoomDto;
+        return allChatRoomDto;
     }
 
     @Transactional

--- a/33ma3/src/main/java/softeer/be33ma3/service/ChatService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/ChatService.java
@@ -85,7 +85,6 @@ public class ChatService {
                 allChatRoomListDto.add(getChatDto(chatRoom, center.getCenterName(), member));
             }
         }
-
         if(member.getMemberType() == CENTER_TYPE) {
             List<ChatRoom> chatRooms = chatRoomRepository.findByCenter_MemberId(member.getMemberId());
             for (ChatRoom chatRoom : chatRooms) {
@@ -115,13 +114,13 @@ public class ChatService {
     }
 
     private void updateAllChatList(Member receiver, ChatRoom chatRoom) {
-        if(receiver.getMemberId() == CENTER_TYPE){
+        if(receiver.getMemberId() == CENTER_TYPE){      //받는 사람이 센터인 경우
             Center center = centerRepository.findByMember_MemberId(receiver.getMemberId()).orElseThrow(() -> new BusinessException(NOT_FOUND_CENTER));
             ChatRoomListDto chatDto = getChatDto(chatRoom, center.getCenterName(), receiver);
             webSocketHandler.sendAllChatData2Client(receiver.getMemberId(), chatDto);   //목록 실시간 전송
             return;
         }
-
+        //받는 사람이 일반 회원인 경우
         ChatRoomListDto chatDto = getChatDto(chatRoom, receiver.getLoginId(), receiver);
         webSocketHandler.sendAllChatData2Client(receiver.getMemberId(), chatDto);
     }

--- a/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
@@ -171,7 +171,7 @@ public class PostService {
     private Post validPostAndMember(Member member, Long postId) {
         Post post = postRepository.findById(postId).orElseThrow(() -> new BusinessException(NOT_FOUND_POST));
 
-        if (!post.getMember().equals(member)) {
+        if (!post.getMember().getMemberId().equals(member.getMemberId())) {
             throw new BusinessException(AUTHOR_ONLY_ACCESS);
         }
 

--- a/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
@@ -70,15 +70,19 @@ public class PostService {
         }
         Region region = getRegion(postCreateDto.getLocation());
 
-        //이미지 저장
-        ImageListDto imageListDto = imageService.saveImage(multipartFiles);
-
         //게시글 저장
         Post post = Post.createPost(postCreateDto, region, currentMember);
         Post savedPost = postRepository.save(post);
 
         //정비소랑 게시물 매핑하기
         centerAndPostMapping(postCreateDto, savedPost);
+
+        if(multipartFiles == null){     //이미지가 없는 경우
+            return savedPost.getPostId();
+        }
+
+        //이미지 저장
+        ImageListDto imageListDto = imageService.saveImage(multipartFiles);
 
         //이미지랑 게시물 매핑하기
         List<Image> images = imageRepository.findAllById(imageListDto.getImageIds());

--- a/33ma3/src/main/java/softeer/be33ma3/websocket/ExitRoomMember.java
+++ b/33ma3/src/main/java/softeer/be33ma3/websocket/ExitRoomMember.java
@@ -1,11 +1,12 @@
 package softeer.be33ma3.websocket;
 
 import lombok.Data;
-import lombok.RequiredArgsConstructor;
+import lombok.NoArgsConstructor;
 
 @Data
-@RequiredArgsConstructor
-public class ExitMember {
+@NoArgsConstructor
+public class ExitRoomMember {
     private String type;
+    private Long roomId;
     private Long memberId;
 }

--- a/33ma3/src/main/java/softeer/be33ma3/websocket/HandShakeInterceptor.java
+++ b/33ma3/src/main/java/softeer/be33ma3/websocket/HandShakeInterceptor.java
@@ -1,3 +1,4 @@
+
 package softeer.be33ma3.websocket;
 
 import lombok.extern.slf4j.Slf4j;
@@ -26,11 +27,17 @@ public class HandShakeInterceptor implements HandshakeInterceptor {
         }
         // 게시글 조회 관련 실시간 통신 요청일 경우
         if(parts[2].equals("post")) {
-            return attributesToHandler(response, attributes, parts, "postId");
+            try {
+                return attributesToHandler(response, attributes, parts, "postId");
+            } catch(NumberFormatException e) {
+                log.error("웹소켓 연결 실패: 게시글 아이디, 멤버 아이디가 포함되어야 합니다.");
+                response.setStatusCode(HttpStatus.FORBIDDEN);
+                response.getBody().write("웹소켓 연결 실패: 게시글 아이디와 멤버 아이디를 포함해주세요.".getBytes());
+                return false;
+            }
         }
-
         if(parts[2].equals("chat")) {
-            return attributesToHandler(response, attributes, parts, "roomId");
+            return attributesToHandler(response, attributes, parts, "chat");
         }
 
         if(parts[2].equals("chatRoom")) {
@@ -40,27 +47,25 @@ public class HandShakeInterceptor implements HandshakeInterceptor {
         return false;
     }
 
-    private static boolean attributesToHandler(ServerHttpResponse response, Map<String, Object> attributes, String[] parts, String part3) throws IOException {
-        try{
-            Long memberId = Long.parseLong(parts[4]);
+        private boolean attributesToHandler(ServerHttpResponse response, Map<String, Object> attributes, String[] parts, String part3) throws IOException {
             // WebSocketHandler 에 전달될 속성 추가하기
-            attributes.put("type", parts[2]);
-            attributes.put("memberId", memberId);
+            try {
+                attributes.put("type", parts[2]);
+                if (!parts[2].equals("chatRoom")) {
+                    // 연결 요청 엔드 포인트에서 데이터 파싱
+                    attributes.put(part3, Long.parseLong(parts[3]));
+                    return true;
+                }
 
-            if(parts[2] == "chatRoom"){
+                Long memberId = Long.parseLong(parts[4]);
+                attributes.put("memberId", memberId);
                 return true;
+            }catch(NumberFormatException e) {
+                log.error("웹소켓 연결 실패: 멤버 아이디가 포함되어야 합니다.");
+                response.setStatusCode(HttpStatus.FORBIDDEN);
+                response.getBody().write("웹소켓 연결 실패: 멤버 아이디를 포함해주세요.".getBytes());
+                return false;
             }
-            // 연결 요청 엔드 포인트에서 데이터 파싱
-            Long part3Id = Long.parseLong(parts[3]);
-            attributes.put(part3, part3Id);
-            return true;
-
-        } catch(NumberFormatException e) {
-            log.error("웹소켓 연결 실패");
-            response.setStatusCode(HttpStatus.FORBIDDEN);
-            response.getBody().write("웹소켓 연결 실패 ".getBytes());
-            return false;
-        }
     }
 
     @Override
@@ -68,3 +73,6 @@ public class HandShakeInterceptor implements HandshakeInterceptor {
         log.info("handshake success!");
     }
 }
+
+
+

--- a/33ma3/src/main/java/softeer/be33ma3/websocket/HandShakeInterceptor.java
+++ b/33ma3/src/main/java/softeer/be33ma3/websocket/HandShakeInterceptor.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.server.HandshakeInterceptor;
 
+import java.io.IOException;
 import java.util.Map;
 
 @Component
@@ -60,7 +61,28 @@ public class HandShakeInterceptor implements HandshakeInterceptor {
             }
         }
 
+        if(parts[2].equals("chatRoom")) {
+            return putChatRoom(response, attributes, parts);
+        }
+
         return false;
+    }
+
+    private static boolean putChatRoom(ServerHttpResponse response, Map<String, Object> attributes, String[] parts) throws IOException {
+        try {
+            // 연결 요청 엔드 포인트에서 데이터 파싱
+            Long memberId = Long.parseLong(parts[4]);
+            // WebSocketHandler 에 전달될 속성 추가하기
+            attributes.put("type", parts[2]);
+            attributes.put("roomId", "all");
+            attributes.put("memberId", memberId);
+            return true;
+        } catch(NumberFormatException e) {
+            log.error("웹소켓 연결 실패: 멤버 아이디가 포함되어야 합니다.");
+            response.setStatusCode(HttpStatus.FORBIDDEN);
+            response.getBody().write("웹소켓 연결 실패, 멤버 아이디를 포함해주세요.".getBytes());
+            return false;
+        }
     }
 
     @Override

--- a/33ma3/src/main/java/softeer/be33ma3/websocket/HandShakeInterceptor.java
+++ b/33ma3/src/main/java/softeer/be33ma3/websocket/HandShakeInterceptor.java
@@ -26,61 +26,39 @@ public class HandShakeInterceptor implements HandshakeInterceptor {
         }
         // 게시글 조회 관련 실시간 통신 요청일 경우
         if(parts[2].equals("post")) {
-            try {
-                // 연결 요청 엔드 포인트에서 데이터 파싱
-                Long postId = Long.parseLong(parts[3]);
-                Long memberId = Long.parseLong(parts[4]);
-                // WebSocketHandler 에 전달될 속성 추가하기
-                attributes.put("type", parts[2]);
-                attributes.put("postId", postId);
-                attributes.put("memberId", memberId);
-                return true;
-            } catch(NumberFormatException e) {
-                log.error("웹소켓 연결 실패: 게시글 아이디, 멤버 아이디가 포함되어야 합니다.");
-                response.setStatusCode(HttpStatus.FORBIDDEN);
-                response.getBody().write("웹소켓 연결 실패, 게시글 아이디와 멤버 아이디를 포함해주세요.".getBytes());
-                return false;
-            }
+            return attributesToHandler(response, attributes, parts, "postId");
         }
 
         if(parts[2].equals("chat")) {
-            try {
-                // 연결 요청 엔드 포인트에서 데이터 파싱
-                Long roomId = Long.parseLong(parts[3]);
-                Long memberId = Long.parseLong(parts[4]);
-                // WebSocketHandler 에 전달될 속성 추가하기
-                attributes.put("type", parts[2]);
-                attributes.put("roomId", roomId);
-                attributes.put("memberId", memberId);
-                return true;
-        } catch(NumberFormatException e) {
-            log.error("웹소켓 연결 실패: 채팅방 아이디, 멤버 아이디가 포함되어야 합니다.");
-            response.setStatusCode(HttpStatus.FORBIDDEN);
-            response.getBody().write("웹소켓 연결 실패, 채팅방 아이디와 멤버 아이디를 포함해주세요.".getBytes());
-            return false;
-            }
+            return attributesToHandler(response, attributes, parts, "roomId");
         }
 
         if(parts[2].equals("chatRoom")) {
-            return putChatRoom(response, attributes, parts);
+            return attributesToHandler(response, attributes, parts, "all");
         }
 
         return false;
     }
 
-    private static boolean putChatRoom(ServerHttpResponse response, Map<String, Object> attributes, String[] parts) throws IOException {
-        try {
-            // 연결 요청 엔드 포인트에서 데이터 파싱
+    private static boolean attributesToHandler(ServerHttpResponse response, Map<String, Object> attributes, String[] parts, String part3) throws IOException {
+        try{
             Long memberId = Long.parseLong(parts[4]);
             // WebSocketHandler 에 전달될 속성 추가하기
             attributes.put("type", parts[2]);
-            attributes.put("roomId", "all");
             attributes.put("memberId", memberId);
+
+            if(parts[2] == "chatRoom"){
+                return true;
+            }
+            // 연결 요청 엔드 포인트에서 데이터 파싱
+            Long part3Id = Long.parseLong(parts[3]);
+            attributes.put(part3, part3Id);
             return true;
+
         } catch(NumberFormatException e) {
-            log.error("웹소켓 연결 실패: 멤버 아이디가 포함되어야 합니다.");
+            log.error("웹소켓 연결 실패");
             response.setStatusCode(HttpStatus.FORBIDDEN);
-            response.getBody().write("웹소켓 연결 실패, 멤버 아이디를 포함해주세요.".getBytes());
+            response.getBody().write("웹소켓 연결 실패 ".getBytes());
             return false;
         }
     }

--- a/33ma3/src/main/java/softeer/be33ma3/websocket/HandShakeInterceptor.java
+++ b/33ma3/src/main/java/softeer/be33ma3/websocket/HandShakeInterceptor.java
@@ -73,6 +73,3 @@ public class HandShakeInterceptor implements HandshakeInterceptor {
         log.info("handshake success!");
     }
 }
-
-
-

--- a/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketHandler.java
+++ b/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketHandler.java
@@ -47,6 +47,10 @@ public class WebSocketHandler extends TextWebSocketHandler {
                 Long senderId = (Long) attributes.get("memberId");
                 webSocketService.saveInChat(roomId, senderId, session);
             }
+            if(type.equals("chatRoom")){
+                Long memberId = (Long) attributes.get("memberId");
+                webSocketService.saveInChatRoom(memberId, session);
+            }
         }
     }
     @Override

--- a/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketHandler.java
+++ b/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketHandler.java
@@ -49,7 +49,7 @@ public class WebSocketHandler extends TextWebSocketHandler {
             }
             if(type.equals("chatRoom")){
                 Long memberId = (Long) attributes.get("memberId");
-                webSocketService.saveInChatRoom(memberId, session);
+                webSocketService.saveInAllChatRoom(memberId, session);
             }
         }
     }

--- a/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketHandler.java
+++ b/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketHandler.java
@@ -70,6 +70,14 @@ public class WebSocketHandler extends TextWebSocketHandler {
             log.error("실시간 데이터 전송 에러");
         }
     }
+
+    public void sendAllChatData2Client(Long memberId, Object data) {
+        try {
+            webSocketService.sendAllChatRoomData(memberId, data);
+        } catch(IOException e) {
+            log.error("실시간 데이터 전송 에러");
+        }
+    }
     public void deletePostRoom(Long postId) {
         webSocketService.deletePostRoom(postId);
     }

--- a/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketRepository.java
+++ b/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketRepository.java
@@ -25,6 +25,9 @@ public class WebSocketRepository {
         return sessions.get(memberId);
     }
 
+    public WebSocketSession findAllChatRoomSessionByMemberId(Long memberId) {
+        return allChatRoomSessions.get(memberId);
+    }
     public void saveMemberInPost(Long postId, Long memberId) {
         Set<Long> members = new HashSet<>();
         if (postRoom.containsKey(postId)) {

--- a/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketRepository.java
+++ b/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketRepository.java
@@ -15,7 +15,7 @@ public class WebSocketRepository {
     private final Map<Long, Set<Long>> postRoom = new ConcurrentHashMap<>();    // postId : set of memberId
     private final Map<Long, Set<Long>> chatRoom = new ConcurrentHashMap<>();    // roomId : set of memberId
     private final Map<Long, WebSocketSession> sessions = new ConcurrentHashMap<>();     // memberId : WebSocketSession
-    private final Map<Long, WebSocketSession> allChatRoomSessions = new ConcurrentHashMap<>();      //memberId: WebSocketSession
+    private final Map<Long, WebSocketSession> chatRoomListSessions = new ConcurrentHashMap<>();      //memberId: WebSocketSession
 
     public Set<Long> findAllMemberInPost(Long postId) {
         return postRoom.get(postId);
@@ -26,7 +26,7 @@ public class WebSocketRepository {
     }
 
     public WebSocketSession findAllChatRoomSessionByMemberId(Long memberId) {
-        return allChatRoomSessions.get(memberId);
+        return chatRoomListSessions.get(memberId);
     }
     public void saveMemberInPost(Long postId, Long memberId) {
         Set<Long> members = new HashSet<>();
@@ -53,8 +53,8 @@ public class WebSocketRepository {
         log.info("{}번 유저 웹소켓 세션 저장 성공", memberId);
     }
 
-    public void saveAllChatRoomSessionWithMemberId(Long memberId, WebSocketSession session) {
-        allChatRoomSessions.put(memberId, session);
+    public void saveChatRoomListSessionWithMemberId(Long memberId, WebSocketSession session) {
+        chatRoomListSessions.put(memberId, session);
         log.info("{}번 유저 웹소켓 세션 저장 성공 - 목록", memberId);
     }
 
@@ -67,16 +67,6 @@ public class WebSocketRepository {
             postRoom.remove(postId);
     }
 
-    public void deleteSessionWithMemberId(Long memberId) {
-        sessions.remove(memberId);
-        log.info("세션 삭제 완료! 세션 저장소 크키: {}", sessions.size());
-    }
-
-    // 게시글 만료시 호출
-    public void deletePostRoom(Long postId) {
-        postRoom.remove(postId);
-    }
-
     public void deleteMemberInChatRoom(Long roomId, Long memberId) {
         Set<Long> members = chatRoom.get(roomId);
         if (members != null) {
@@ -86,4 +76,19 @@ public class WebSocketRepository {
             }
         }
     }
+
+    public void deleteSessionWithMemberId(Long memberId) {
+        sessions.remove(memberId);
+        log.info("세션 삭제 완료! 세션 저장소 크키: {}", sessions.size());
+    }
+    public void deleteChatRoomListSessionWithMemberId(Long memberId) {
+        chatRoomListSessions.remove(memberId);
+        log.info("목록: 세션 삭제 완료! 세션 저장소 크키: {}", sessions.size());
+    }
+
+    // 게시글 만료시 호출
+    public void deletePostRoom(Long postId) {
+        postRoom.remove(postId);
+    }
+
 }

--- a/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketRepository.java
+++ b/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketRepository.java
@@ -15,7 +15,7 @@ public class WebSocketRepository {
     private final Map<Long, Set<Long>> postRoom = new ConcurrentHashMap<>();    // postId : set of memberId
     private final Map<Long, Set<Long>> chatRoom = new ConcurrentHashMap<>();    // roomId : set of memberId
     private final Map<Long, WebSocketSession> sessions = new ConcurrentHashMap<>();     // memberId : WebSocketSession
-    private final Map<Long, WebSocketSession> chatRoomListSessions = new ConcurrentHashMap<>();      //memberId: WebSocketSession
+    private final Map<Long, WebSocketSession> allChatRoomSessions = new ConcurrentHashMap<>();      //memberId: WebSocketSession
 
     public Set<Long> findAllMemberInPost(Long postId) {
         return postRoom.get(postId);
@@ -26,7 +26,7 @@ public class WebSocketRepository {
     }
 
     public WebSocketSession findAllChatRoomSessionByMemberId(Long memberId) {
-        return chatRoomListSessions.get(memberId);
+        return allChatRoomSessions.get(memberId);
     }
     public void saveMemberInPost(Long postId, Long memberId) {
         Set<Long> members = new HashSet<>();
@@ -53,8 +53,8 @@ public class WebSocketRepository {
         log.info("{}번 유저 웹소켓 세션 저장 성공", memberId);
     }
 
-    public void saveChatRoomListSessionWithMemberId(Long memberId, WebSocketSession session) {
-        chatRoomListSessions.put(memberId, session);
+    public void saveAllChatRoomSessionWithMemberId(Long memberId, WebSocketSession session) {
+        allChatRoomSessions.put(memberId, session);
         log.info("{}번 유저 웹소켓 세션 저장 성공 - 목록", memberId);
     }
 
@@ -81,8 +81,8 @@ public class WebSocketRepository {
         sessions.remove(memberId);
         log.info("세션 삭제 완료! 세션 저장소 크키: {}", sessions.size());
     }
-    public void deleteChatRoomListSessionWithMemberId(Long memberId) {
-        chatRoomListSessions.remove(memberId);
+    public void deleteAllChatRoomSessionWithMemberId(Long memberId) {
+        allChatRoomSessions.remove(memberId);
         log.info("목록: 세션 삭제 완료! 세션 저장소 크키: {}", sessions.size());
     }
 

--- a/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketRepository.java
+++ b/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketRepository.java
@@ -15,9 +15,14 @@ public class WebSocketRepository {
     private final Map<Long, Set<Long>> postRoom = new ConcurrentHashMap<>();    // postId : set of memberId
     private final Map<Long, Set<Long>> chatRoom = new ConcurrentHashMap<>();    // roomId : set of memberId
     private final Map<Long, WebSocketSession> sessions = new ConcurrentHashMap<>();     // memberId : WebSocketSession
+    private final Map<Long, WebSocketSession> allChatRoomSessions = new ConcurrentHashMap<>();      //memberId: WebSocketSession
 
     public Set<Long> findAllMemberInPost(Long postId) {
         return postRoom.get(postId);
+    }
+
+    public WebSocketSession findSessionByMemberId(Long memberId) {
+        return sessions.get(memberId);
     }
 
     public void saveMemberInPost(Long postId, Long memberId) {
@@ -45,8 +50,9 @@ public class WebSocketRepository {
         log.info("{}번 유저 웹소켓 세션 저장 성공", memberId);
     }
 
-    public WebSocketSession findSessionByMemberId(Long memberId) {
-        return sessions.get(memberId);
+    public void saveAllChatRoomSessionWithMemberId(Long memberId, WebSocketSession session) {
+        allChatRoomSessions.put(memberId, session);
+        log.info("{}번 유저 웹소켓 세션 저장 성공 - 목록", memberId);
     }
 
     public void deleteMemberInPost(Long postId, Long memberId) {

--- a/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketService.java
@@ -22,12 +22,16 @@ public class WebSocketService {
         String payload = message.getPayload();
         // 게시글 관련 웹 소켓 연결이 종료된 유저가 있다고 메세지를 받았을 경우
         if(payload.contains("post") && payload.contains("memberId")) {
-            ExitMember exitMember = objectMapper.readValue(payload, ExitMember.class);
-            closePostConnection(exitMember.getRoomId(), exitMember.getMemberId());
+            ExitRoomMember exitRoomMember = objectMapper.readValue(payload, ExitRoomMember.class);
+            closePostConnection(exitRoomMember.getRoomId(), exitRoomMember.getMemberId());
         }
         if(payload.contains("chat") && payload.contains("memberId")) {
+            ExitRoomMember exitRoomMember = objectMapper.readValue(payload, ExitRoomMember.class);
+            closeChatConnection(exitRoomMember.getRoomId(), exitRoomMember.getMemberId());
+        }
+        if(payload.contains("chatRoom") && payload.contains("memberId")){
             ExitMember exitMember = objectMapper.readValue(payload, ExitMember.class);
-            closeChatConnection(exitMember.getRoomId(), exitMember.getMemberId());
+            closeChatRoomListConnection(exitMember.getMemberId());
         }
 
         log.info("메세지 수신 성공: {}", payload); // 수신한 메세지 log
@@ -46,7 +50,7 @@ public class WebSocketService {
     }
 
     public void saveInChatRoom(Long memberId, WebSocketSession session) {
-        webSocketRepository.saveAllChatRoomSessionWithMemberId(memberId, session);
+        webSocketRepository.saveChatRoomListSessionWithMemberId(memberId, session);
     }
 
     // 데이터 (클래스 객체) 전송
@@ -82,6 +86,10 @@ public class WebSocketService {
     private void closeChatConnection(Long roomId, Long memberId) {
         webSocketRepository.deleteMemberInChatRoom(roomId, memberId);
         webSocketRepository.deleteSessionWithMemberId(memberId);
+    }
+
+    private void closeChatRoomListConnection(Long memberId) {
+        webSocketRepository.deleteChatRoomListSessionWithMemberId(memberId);
     }
 
     public void deletePostRoom(Long postId) {

--- a/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketService.java
@@ -40,9 +40,13 @@ public class WebSocketService {
         webSocketRepository.saveSessionWithMemberId(memberId, session);
     }
 
-    public void saveInChat(Long roomId, Long receiverId, WebSocketSession session) {
-        webSocketRepository.saveMemberInChat(roomId, receiverId);
-        webSocketRepository.saveSessionWithMemberId(receiverId, session);
+    public void saveInChat(Long roomId, Long memberId, WebSocketSession session) {
+        webSocketRepository.saveMemberInChat(roomId, memberId);
+        webSocketRepository.saveSessionWithMemberId(memberId, session);
+    }
+
+    public void saveInChatRoom(Long memberId, WebSocketSession session) {
+        webSocketRepository.saveAllChatRoomSessionWithMemberId(memberId, session);
     }
 
     // 데이터 (클래스 객체) 전송

--- a/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketService.java
@@ -66,14 +66,8 @@ public class WebSocketService {
     }
 
     public void sendAllChatRoomData(Long memberId, Object data) throws IOException {
-        if(memberId == null || data == null)
-            return;
         // 클라이언트에 해당하는 세션 가져오기
         WebSocketSession session = webSocketRepository.findAllChatRoomSessionByMemberId(memberId);
-        if(session == null) {
-            log.info("웹 소켓 연결이 되어있지 않음");
-            return;
-        }
         // data 직렬화
         String jsonString = objectMapper.writeValueAsString(data);
         // 데이터 전송

--- a/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketService.java
@@ -65,6 +65,21 @@ public class WebSocketService {
         session.sendMessage(new TextMessage(jsonString));
     }
 
+    public void sendAllChatRoomData(Long memberId, Object data) throws IOException {
+        if(memberId == null || data == null)
+            return;
+        // 클라이언트에 해당하는 세션 가져오기
+        WebSocketSession session = webSocketRepository.findAllChatRoomSessionByMemberId(memberId);
+        if(session == null) {
+            log.info("웹 소켓 연결이 되어있지 않음");
+            return;
+        }
+        // data 직렬화
+        String jsonString = objectMapper.writeValueAsString(data);
+        // 데이터 전송
+        session.sendMessage(new TextMessage(jsonString));
+    }
+
     private void closePostConnection(Long postId, Long memberId) {
         webSocketRepository.deleteMemberInPost(postId, memberId);
         webSocketRepository.deleteSessionWithMemberId(memberId);

--- a/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketService.java
@@ -31,7 +31,7 @@ public class WebSocketService {
         }
         if(payload.contains("chatRoom") && payload.contains("memberId")){
             ExitMember exitMember = objectMapper.readValue(payload, ExitMember.class);
-            closeChatRoomListConnection(exitMember.getMemberId());
+            closeAllChatRoomConnection(exitMember.getMemberId());
         }
 
         log.info("메세지 수신 성공: {}", payload); // 수신한 메세지 log
@@ -49,8 +49,8 @@ public class WebSocketService {
         webSocketRepository.saveSessionWithMemberId(memberId, session);
     }
 
-    public void saveInChatRoom(Long memberId, WebSocketSession session) {
-        webSocketRepository.saveChatRoomListSessionWithMemberId(memberId, session);
+    public void saveInAllChatRoom(Long memberId, WebSocketSession session) {
+        webSocketRepository.saveAllChatRoomSessionWithMemberId(memberId, session);
     }
 
     // 데이터 (클래스 객체) 전송
@@ -88,8 +88,8 @@ public class WebSocketService {
         webSocketRepository.deleteSessionWithMemberId(memberId);
     }
 
-    private void closeChatRoomListConnection(Long memberId) {
-        webSocketRepository.deleteChatRoomListSessionWithMemberId(memberId);
+    private void closeAllChatRoomConnection(Long memberId) {
+        webSocketRepository.deleteAllChatRoomSessionWithMemberId(memberId);
     }
 
     public void deletePostRoom(Long postId) {

--- a/33ma3/src/test/java/softeer/be33ma3/jwt/JwtServiceTest.java
+++ b/33ma3/src/test/java/softeer/be33ma3/jwt/JwtServiceTest.java
@@ -10,12 +10,13 @@ import org.springframework.test.context.ActiveProfiles;
 import softeer.be33ma3.domain.Member;
 import softeer.be33ma3.dto.request.LoginDto;
 import softeer.be33ma3.dto.response.LoginSuccessDto;
-import softeer.be33ma3.exception.JwtTokenException;
+import softeer.be33ma3.exception.BusinessException;
 import softeer.be33ma3.repository.MemberRepository;
 import softeer.be33ma3.service.MemberService;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static softeer.be33ma3.exception.ErrorCode.REFRESH_TOKEN_NOT_VALID;
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -60,7 +61,6 @@ class JwtServiceTest {
 
         //when //then
         assertThatThrownBy(() -> jwtService.reissue(refreshToken))
-                .isInstanceOf(JwtTokenException.class)
-                .hasMessage("올바르지 않은 리프레시 토큰");
+                .isInstanceOf(BusinessException.class);
     }
 }

--- a/33ma3/src/test/java/softeer/be33ma3/service/PostServiceTest.java
+++ b/33ma3/src/test/java/softeer/be33ma3/service/PostServiceTest.java
@@ -11,6 +11,7 @@ import softeer.be33ma3.domain.Member;
 import softeer.be33ma3.domain.Post;
 import softeer.be33ma3.domain.Region;
 import softeer.be33ma3.dto.request.PostCreateDto;
+import softeer.be33ma3.exception.BusinessException;
 import softeer.be33ma3.repository.MemberRepository;
 import softeer.be33ma3.repository.PostRepository;
 import softeer.be33ma3.repository.RegionRepository;
@@ -78,8 +79,7 @@ class PostServiceTest {
 
         //when //then
         assertThatThrownBy(() -> postService.editPost(member2, savedPost.getPostId(), postEditDto))
-                .isInstanceOf(UnauthorizedException.class)
-                .hasMessage("작성자만 가능합니다.");
+                .isInstanceOf(BusinessException.class);
     }
 
     private Post savePost(Region region, Member member1) {


### PR DESCRIPTION
## 구현 내용
- [x] 문의 목록 실시간으로 전송하는 기능 구현

## 고민 사항
- 채팅방은 실시간으로 구현했는데, 채팅목록 또한 실시간으로 업데이트 해야한다는 사실을 간과하고 있었다~
-  채팅 목록 또한 실시간으로 전송하기 위해서 먼저 상대방이 채팅방에 있는지 확인을 한다. 채팅방에 있다면 채팅방으로 메세지를 실시간으로 전송한다. 만약 채팅방에 없다면, 상대방의 목록 세션이 존재하는지 확인한다. 목록 세션이 존재한다면 해당 목록 세션으로 업데이트 된 카톡 내용을 전달하도록 했다! 모든 세션이 없다면 알림 테이블에 저장하도록 구현했다.!!

## 기타
프론트와 테스트를 해봤는데 실시간으로 전송 되는것을 확인했다~~