### PR TITLE
채팅 내역 렌더링 관련 기능 수정 #164

### DIFF
--- a/src/constants/url.js
+++ b/src/constants/url.js
@@ -1,4 +1,4 @@
-export const BASE_URL = "http://15.165.162.126:8080/";
-export const IP = "15.165.162.126:8080";
-// export const BASE_URL = "http://192.168.1.192:8080/";
-// export const IP = "192.168.1.192:8080";
+// export const BASE_URL = "http://15.165.162.126:8080/";
+// export const IP = "15.165.162.126:8080";
+export const BASE_URL = "http://192.168.1.141:8080/";
+export const IP = "192.168.1.141:8080";

--- a/src/pages/AuthenticationPage/index.jsx
+++ b/src/pages/AuthenticationPage/index.jsx
@@ -1,0 +1,3 @@
+function AuthenticationPage() {}
+
+export { AuthenticationPage };

--- a/src/pages/ChatRoomPage/components/ChatList.jsx
+++ b/src/pages/ChatRoomPage/components/ChatList.jsx
@@ -58,17 +58,6 @@ function ChatList(props) {
     ws.onerror = (error) => {
       console.error("웹소켓 오류 발생:", error);
     };
-
-    fetch(`${BASE_URL}chat/history/${props.roomId}`, {
-      headers: {
-        Authorization: props.accessToken,
-        Accept: "application/json",
-      },
-    })
-      .then((res) => res.json())
-      .then((data) => {
-        setChatHistory(data.data);
-      });
     // 컴포넌트 언마운트 시 웹소켓 연결 종료
     return () => {
       if (ws.readyState === WebSocket.OPEN) {
@@ -81,11 +70,24 @@ function ChatList(props) {
         ws.close();
       }
     };
-  }, []);
+  }, [props.roomId]);
 
   useEffect(() => {
     scrollToBottom(scrollRef.current);
   }, [chatHistory]);
+
+  useEffect(() => {
+    fetch(`${BASE_URL}chat/history/${props.roomId}`, {
+      headers: {
+        Authorization: props.accessToken,
+        Accept: "application/json",
+      },
+    })
+      .then((res) => res.json())
+      .then((data) => {
+        setChatHistory(data.data);
+      });
+  }, [props.roomId]);
 
   return (
     <ChatContainer>

--- a/src/pages/ChatRoomPage/components/Message.jsx
+++ b/src/pages/ChatRoomPage/components/Message.jsx
@@ -73,7 +73,7 @@ function Message(props) {
   const navigate = useNavigate();
   function handleOnClick() {
     navigate(
-      `/chat-room?mode=chat&client-id=${props.clientId}&center-id=${props.centerId}&room-id=${props.info.roomId}&center-name=${props.info.memberName}`
+      `?mode=chat&client-id=${props.info.clientId}&center-id=${props.info.centerId}&room-id=${props.info.roomId}&center-name=${props.info.memberName}`
     );
   }
 

--- a/src/pages/PostPage/components/OfferList.jsx
+++ b/src/pages/PostPage/components/OfferList.jsx
@@ -43,7 +43,7 @@ function OfferList({ prevOfferList, offerList, disabled, handleSelectOffer }) {
           handleSelectOffer={() =>
             handleSelectOffer(offerList[focusOffer].offerId)
           }
-          centerId={offerList[0].memberId}
+          centerId={offerList[focusOffer].memberId}
         />
       )}
     </>


### PR DESCRIPTION
## 구현 내용
- [x] 방마다 해당 채팅 내역을 분리해서 렌더링 실시

## 고민 사항
채팅 소켓의 경우 채팅방 들어갈 때마다 연결하고 나갈 때 해제하는 방식을 사용했다. 독립성은 있지만 리소스 사용이 빈번하다는 점이 단점이라 문의 내역 생성시 소켓을 연결하는 방안을 검토했으나 많은 채팅방을 생성할만한 서비스가 아니기에 독립성을 유지하기로 결정했다.

## 기타
