### PR TITLE
댓글 업데이트 시 실시간 데이터 전송 방식 변경, 웹소켓 통신 방식 보완 #180

### DIFF
--- a/33ma3/src/main/java/softeer/be33ma3/controller/OfferController.java
+++ b/33ma3/src/main/java/softeer/be33ma3/controller/OfferController.java
@@ -55,7 +55,6 @@ public class OfferController {
                                          @RequestBody @Valid OfferCreateDto offerCreateDto,
                                          @Schema(hidden = true) @CurrentUser Member member) {
         Long offerId = offerService.createOffer(postId, offerCreateDto, member);
-        offerService.sendAboutOfferUpdate(postId);
         return ResponseEntity.ok(DataResponse.success("입찰 성공", offerId));
     }
 
@@ -74,7 +73,6 @@ public class OfferController {
                                          @RequestBody @Valid OfferCreateDto offerCreateDto,
                                          @Schema(hidden = true) @CurrentUser Member member) {
         offerService.updateOffer(postId, offerId, offerCreateDto, member);
-        offerService.sendAboutOfferUpdate(postId);
         return ResponseEntity.ok(DataResponse.success("댓글 수정 성공", offerId));
     }
 
@@ -92,7 +90,6 @@ public class OfferController {
                                          @PathVariable("offer_id") Long offerId,
                                          @Schema(hidden = true) @CurrentUser Member member) {
         offerService.deleteOffer(postId, offerId, member);
-        offerService.sendAboutOfferUpdate(postId);
         return ResponseEntity.ok(DataResponse.success("댓글 삭제 성공", offerId));
     }
 

--- a/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
@@ -36,6 +36,10 @@ public class OfferService {
     private final ReviewRepository reviewRepository;
     private final WebSocketHandler webSocketHandler;
 
+    private static final String OFFER_CREATE = "CREATE";
+    private static final String OFFER_UPDATE = "UPDATE";
+    private static final String OFFER_DELETE = "DELETE";
+
     // 견적 제시 댓글 하나 반환
     public OfferDetailDto showOffer(Long postId, Long offerId) {
         // 1. 해당 게시글 가져오기
@@ -61,7 +65,7 @@ public class OfferService {
         Offer offer = offerCreateDto.toEntity(post, member);
         Offer savedOffer = offerRepository.save(offer);
         // 4. 업데이트된 사항 실시간 전송
-        sendAboutOfferUpdate(post, "CREATE", savedOffer);
+        sendAboutOfferUpdate(post, OFFER_CREATE, savedOffer);
         return savedOffer.getOfferId();
     }
 
@@ -82,7 +86,7 @@ public class OfferService {
         offer.setContents(offerCreateDto.getContents());
         offerRepository.save(offer);
         // 5. 업데이트된 사항 실시간 전송
-        sendAboutOfferUpdate(post, "UPDATE", offer);
+        sendAboutOfferUpdate(post, OFFER_UPDATE, offer);
     }
 
     // 견적 제시 댓글 삭제
@@ -98,7 +102,7 @@ public class OfferService {
         // 4. 댓글 삭제
         offerRepository.delete(offer);
         // 5. 업데이트된 사항 실시간 전송
-        sendAboutOfferUpdate(post, "DELETE", offer);
+        sendAboutOfferUpdate(post, OFFER_DELETE, offer);
     }
 
     // 견적 제시 댓글 낙찰
@@ -129,7 +133,7 @@ public class OfferService {
 
     public void sendAboutOfferUpdate(Post post, String requestType, Offer offer) {
         Object data = offer.getOfferId();
-        if(!requestType.equals("DELETE")) {
+        if(!requestType.equals(OFFER_DELETE)) {
             Double score = reviewRepository.findAvgScoreByCenterId(offer.getCenter().getMemberId()).orElse(0.0);
             data = OfferDetailDto.fromEntity(offer, score, offer.getCenter().getImage().getLink());
         }

--- a/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
@@ -60,6 +60,8 @@ public class OfferService {
         // 3. 댓글 생성하여 저장하기
         Offer offer = offerCreateDto.toEntity(post, member);
         Offer savedOffer = offerRepository.save(offer);
+        // 4. 업데이트된 사항 실시간 전송
+        sendAboutOfferUpdate(post, "CREATE", savedOffer);
         return savedOffer.getOfferId();
     }
 
@@ -67,7 +69,7 @@ public class OfferService {
     @Transactional
     public void updateOffer(Long postId, Long offerId, OfferCreateDto offerCreateDto, Member member) {
         // 1. 해당 게시글이 마감 전인지 확인
-        checkNotDonePost(postId);
+        Post post = checkNotDonePost(postId);
         // 2. 기존 댓글 가져오기
         Offer offer = offerRepository.findByPost_PostIdAndOfferId(postId, offerId).orElseThrow(() -> new BusinessException(NOT_FOUND_OFFER));
         // 3. 수정 가능한지 검증
@@ -75,24 +77,28 @@ public class OfferService {
             throw new BusinessException(AUTHOR_ONLY_ACCESS);
         if(offerCreateDto.getPrice() > offer.getPrice())
             throw new BusinessException(ONLY_LOWER_AMOUNT_ALLOWED);
-        // 5. 댓글 수정하기
+        // 4. 댓글 수정하기
         offer.setPrice(offerCreateDto.getPrice());
         offer.setContents(offerCreateDto.getContents());
         offerRepository.save(offer);
+        // 5. 업데이트된 사항 실시간 전송
+        sendAboutOfferUpdate(post, "UPDATE", offer);
     }
 
     // 견적 제시 댓글 삭제
     @Transactional
     public void deleteOffer(Long postId, Long offerId, Member member) {
         // 1. 해당 게시글이 마감 전인지 확인
-        checkNotDonePost(postId);
+        Post post = checkNotDonePost(postId);
         // 2. 기존 댓글 가져오기
         Offer offer = offerRepository.findByPost_PostIdAndOfferId(postId, offerId).orElseThrow(() -> new BusinessException(NOT_FOUND_OFFER));
         // 3. 삭제 가능한지 검증
         if(!offer.getCenter().equals(member))
             throw new BusinessException(AUTHOR_ONLY_ACCESS);
-        // 5. 댓글 삭제
+        // 4. 댓글 삭제
         offerRepository.delete(offer);
+        // 5. 업데이트된 사항 실시간 전송
+        sendAboutOfferUpdate(post, "DELETE", offer);
     }
 
     // 견적 제시 댓글 낙찰
@@ -101,7 +107,7 @@ public class OfferService {
         // 1. 해당 게시글이 마감 전인지 확인
         Post post = checkNotDonePost(postId);
         // 3. 게시글 작성자의 접근인지 검증
-        if(member.getMemberId() != post.getMember().getMemberId())
+        if(!member.getMemberId().equals(post.getMember().getMemberId()))
             throw new BusinessException(AUTHOR_ONLY_ACCESS);
         // 4. 낙찰을 희망하는 댓글 가져오기
         Offer offer = offerRepository.findByPost_PostIdAndOfferId(postId, offerId).orElseThrow(() -> new BusinessException(NOT_FOUND_OFFER));
@@ -109,8 +115,7 @@ public class OfferService {
         offer.setSelected();
         post.setDone();
         // 6. 서비스 센터들에게 낙찰 또는 경매 마감 메세지 보내기
-        Long selectedMemberId = offer.getCenter().getMemberId();
-        sendMessageAfterSelection(postId, selectedMemberId);
+        sendMessageAfterSelection(postId, offer.getCenter().getMemberId());
         webSocketHandler.deletePostRoom(postId);
     }
 
@@ -122,51 +127,34 @@ public class OfferService {
         return post;
     }
 
-    public void sendAboutOfferUpdate(Long postId) {
-        // 1. 해당 게시글 가져오기
-        Post post = postRepository.findById(postId).orElseThrow(() -> new BusinessException(NOT_FOUND_POST));
-        // 2. 글 작성자 아이디 가져오기
-        Long writerId = post.getMember().getMemberId();
-        // 3. 글 작성자에게 업데이트된 댓글 목록 실시간 전송
-        sendOfferList2Writer(postId, writerId);
-        // 4. 그 외 접속한 유저에게 업데이트된 평균 제시 가격 실시간 전송
-        sendAvgPrice2Others(postId, writerId);
-    }
-
-    // 게시글에 해당하는 견적 제시 댓글 리스트 실시간 전송
-    public void sendOfferList2Writer(Long postId, Long memberId) {
-        // 1. 게시글에 속해있는 댓글 목록 가져오기
-        List<Offer> offerList = offerRepository.findByPost_PostId(postId);
-        List<OfferDetailDto> offerDetailDtos = new ArrayList<>(
-                offerList.stream().map(offer -> {
-                    Double score = reviewRepository.findAvgScoreByCenterId(offer.getCenter().getMemberId()).orElse(0.0);
-                    String profile = offer.getCenter().getImage().getLink();
-                    return OfferDetailDto.fromEntity(offer, score, profile);
-                }).toList());
-        Collections.sort(offerDetailDtos);
-        // 2. 해당 게시글 화면에 진입해 있을 경우 전송하기
-        if(webSocketHandler.isInPostRoom(postId, memberId)) {
-            log.info("게시글 작성자에게 실시간 댓글 전송 진행");
-            webSocketHandler.sendData2Client(memberId, offerDetailDtos);
+    public void sendAboutOfferUpdate(Post post, String requestType, Offer offer) {
+        Object data = offer.getOfferId();
+        if(!requestType.equals("DELETE")) {
+            Double score = reviewRepository.findAvgScoreByCenterId(offer.getCenter().getMemberId()).orElse(0.0);
+            data = OfferDetailDto.fromEntity(offer, score, offer.getCenter().getImage().getLink());
         }
+        // 게시글 작성자에게 데이터 보내기
+        sendData2Writer(post.getMember().getMemberId(), requestType, data);
+        // 그 외 화면을 보고 있는 유저들에게 평균 제시 가격 보내기
+        sendAvgPrice2Others(post.getPostId(), post.getMember().getMemberId());
     }
 
-    // 해당 게시글 화면을 보고 있는 모든 유저들에게 평균 견적 제시 가격 실시간 전송
+    public void sendData2Writer(Long memberId, String requestType, Object data) {
+        DataResponse<?> response = DataResponse.success(requestType, data);
+        webSocketHandler.sendData2Client(memberId, response);
+    }
+
     public void sendAvgPrice2Others(Long postId, Long writerId) {
-        // 1. 해당 게시글을 보고 있는 모든 유저들 가져오기 (글 작성자도 포함되어있을 경우 제외시키기)
-        Set<Long> memberList = webSocketHandler.findAllMemberInPost(postId);
-        if(memberList == null) {
-            log.info("해당 게시글을 보고 있는 유저가 없습니다.");
-            return;
-        }
-        memberList = memberList.stream()
-                .filter(memberId -> !memberId.equals(writerId))
-                .collect(Collectors.toSet());
-        // 2. 평균 견적 가격 계산하기
+        // 평균 견적 가격 계산하기
         Double avgPrice = offerRepository.findAvgPriceByPostId(postId).orElse(0.0);
         AvgPriceDto avgPriceDto = new AvgPriceDto(Math.round( avgPrice * 10 ) / 10.0);
-        // 3. 전송하기
-        memberList.forEach(memberId -> webSocketHandler.sendData2Client(memberId, avgPriceDto));
+        // 해당 화면을 보고 있는 유저 명단 가져오기
+        Set<Long> memberList = webSocketHandler.findAllMemberInPost(postId);
+        memberList.forEach(memberId -> {
+            if(!memberId.equals(writerId)) {
+                webSocketHandler.sendData2Client(memberId, avgPriceDto);
+            }
+        });
     }
 
     // 낙찰 처리 후 서비스 센터들에게 낙찰 메세지, 경매 마감 메세지 전송

--- a/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketHandler.java
+++ b/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketHandler.java
@@ -84,7 +84,4 @@ public class WebSocketHandler extends TextWebSocketHandler {
     public Set<Long> findAllMemberInPost(Long postId) {
         return webSocketService.findAllMemberInPost(postId);
     }
-    public boolean isInPostRoom(Long postId, Long memberId) {
-        return webSocketService.isInPostRoom(postId, memberId);
-    }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketRepository.java
+++ b/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketRepository.java
@@ -44,8 +44,8 @@ public class WebSocketRepository {
     }
 
     public void saveSessionWithMemberId(Long memberId, WebSocketSession webSocketSession) {
-        WebSocketSession existing = sessions.putIfAbsent(memberId, webSocketSession);
-        if(existing == null) {
+        if(sessions.get(memberId) == null || !sessions.get(memberId).isOpen()) {
+            sessions.put(memberId, webSocketSession);
             log.info("{}번 유저 웹소켓 세션 저장 성공", memberId);
             log.info("웹소켓 세션 저장소 크기: {}" , sessions.size());
         }
@@ -55,8 +55,8 @@ public class WebSocketRepository {
     }
 
     public void saveAllChatRoomSessionWithMemberId(Long memberId, WebSocketSession session) {
-        WebSocketSession existing = allChatRoomSessions.putIfAbsent(memberId, session);
-        if(existing == null) {
+        if(allChatRoomSessions.get(memberId) == null || !allChatRoomSessions.get(memberId).isOpen()) {
+            allChatRoomSessions.put(memberId, session);
             log.info("{}번 유저 웹소켓 세션 저장 성공 - 목록", memberId);
         }
         else {

--- a/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketRepository.java
+++ b/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketRepository.java
@@ -12,10 +12,10 @@ import java.util.concurrent.ConcurrentHashMap;
 @Repository
 @Slf4j
 public class WebSocketRepository {
-    private final Map<Long, Set<Long>> postRoom = new ConcurrentHashMap<>();    // postId : set of memberId
-    private final Map<Long, Set<Long>> chatRoom = new ConcurrentHashMap<>();    // roomId : set of memberId
-    private final Map<Long, WebSocketSession> sessions = new ConcurrentHashMap<>();     // memberId : WebSocketSession
-    private final Map<Long, WebSocketSession> allChatRoomSessions = new ConcurrentHashMap<>();      //memberId: WebSocketSession
+    private static final Map<Long, Set<Long>> postRoom = new ConcurrentHashMap<>();    // postId : set of memberId
+    private static final Map<Long, Set<Long>> chatRoom = new ConcurrentHashMap<>();    // roomId : set of memberId
+    private static final Map<Long, WebSocketSession> sessions = new ConcurrentHashMap<>();     // memberId : WebSocketSession
+    private static final Map<Long, WebSocketSession> allChatRoomSessions = new ConcurrentHashMap<>();      //memberId: WebSocketSession
 
     public Set<Long> findAllMemberInPost(Long postId) {
         return postRoom.get(postId);

--- a/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketRepository.java
+++ b/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketRepository.java
@@ -29,35 +29,39 @@ public class WebSocketRepository {
         return allChatRoomSessions.get(memberId);
     }
     public void saveMemberInPost(Long postId, Long memberId) {
-        Set<Long> members = new HashSet<>();
-        if (postRoom.containsKey(postId)) {
-            members = postRoom.get(postId);
-        }
+        Set<Long> members = (postRoom.containsKey(postId)) ? postRoom.get(postId) : new HashSet<>();
         members.add(memberId);
         postRoom.put(postId, members);
         log.info("{}번 게시글에 {}번 유저 입장", postId, memberId);
-        log.info("{}번 게시글에 들어와있는 유저: {}명", postId, postRoom.get(postId).size());
+        log.info("{}번 게시글에 들어와 있는 유저: {}명", postId, postRoom.get(postId).size());
     }
 
     public void saveMemberInChat(Long roomId, Long memberId) {
-        Set<Long> members = new HashSet<>();
-        if(chatRoom.containsKey(roomId)){
-            members = chatRoom.get(roomId);
-        }
+        Set<Long> members = (chatRoom.containsKey(roomId)) ? chatRoom.get(roomId) : new HashSet<>();
         members.add(memberId);
         chatRoom.put(roomId, members);
         log.info("{}번 채팅방에 {}번 유저 입장",  roomId, memberId);
     }
 
     public void saveSessionWithMemberId(Long memberId, WebSocketSession webSocketSession) {
-        sessions.put(memberId, webSocketSession);
-        log.info("{}번 유저 웹소켓 세션 저장 성공", memberId);
-        log.info("웹소켓 세션 저장소 크기: {}" , sessions.size());
+        WebSocketSession existing = sessions.putIfAbsent(memberId, webSocketSession);
+        if(existing == null) {
+            log.info("{}번 유저 웹소켓 세션 저장 성공", memberId);
+            log.info("웹소켓 세션 저장소 크기: {}" , sessions.size());
+        }
+        else {
+            log.info("{}번 유저는 이미 웹소켓 세션이 존재합니다.", memberId);
+        }
     }
 
     public void saveAllChatRoomSessionWithMemberId(Long memberId, WebSocketSession session) {
-        allChatRoomSessions.put(memberId, session);
-        log.info("{}번 유저 웹소켓 세션 저장 성공 - 목록", memberId);
+        WebSocketSession existing = allChatRoomSessions.putIfAbsent(memberId, session);
+        if(existing == null) {
+            log.info("{}번 유저 웹소켓 세션 저장 성공 - 목록", memberId);
+        }
+        else {
+            log.info("{}번 유저는 이미 채팅 목록에 대한 웹소켓 세션이 존재합니다.", memberId);
+        }
     }
 
     public void deleteMemberInPost(Long postId, Long memberId) {

--- a/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketService.java
@@ -56,7 +56,7 @@ public class WebSocketService {
         webSocketRepository.saveAllChatRoomSessionWithMemberId(memberId, session);
     }
 
-    // 데이터 (클래스 객체) 전송
+    // 데이터 전송
     public void sendData(Long memberId, Object data) throws IOException {
         if(memberId == null || data == null)
             return;
@@ -68,8 +68,14 @@ public class WebSocketService {
         }
         // data 직렬화
         String jsonString = objectMapper.writeValueAsString(data);
-        // 데이터 전송
-        session.sendMessage(new TextMessage(jsonString));
+        synchronized (session) {        // 세션 동기화
+            if (session.isOpen()) {
+                // 데이터 전송
+                session.sendMessage(new TextMessage(jsonString));
+            } else {
+                log.info("웹 소켓 세션이 이미 닫혔습니다.");
+            }
+        }
     }
 
     public void sendAllChatRoomData(Long memberId, Object data) throws IOException {

--- a/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/websocket/WebSocketService.java
@@ -103,11 +103,4 @@ public class WebSocketService {
     public Set<Long> findAllMemberInPost(Long postId) {
         return webSocketRepository.findAllMemberInPost(postId);
     }
-
-    public boolean isInPostRoom(Long postId, Long memberId) {
-        Set<Long> memberIds = webSocketRepository.findAllMemberInPost(postId);
-        if(memberIds == null)
-            return false;
-        return memberIds.contains(memberId);
-    }
 }


### PR DESCRIPTION
## 구현 내용
- [x] 댓글 생성, 수정, 삭제 시 글 작성자에게 변경 사항만 실시간 전송
- [x] 댓글 생성, 수정, 삭제 시 글 작성자 외 해당 화면을 보고 있는 유저들에게는 평균 견적 제시 가격 실시간 전송
- [x] ConcurrentHashMap에 멤버 아이디 - 웹소켓 세션 저장 시 이미 해당 멤버에 대해 유효한 웹소켓 세션이 존재하는지 확인, 유효한 세션이 없을 때만 새로 저장하여 데이터 무결성을 보장
- [x] 웹소켓 세션을 이용한 데이터 전송 시 멀티 쓰레드가 동시에 같은 세션을 이용하여 전송할 수 없도록 동기화 처리

## 고민 사항
1. 게시글에 대해 댓글 목록이 업데이트될 때마다 게시글 작성자에게는 업데이트된 전체 댓글 목록을 완성하여 전송하는데, 댓글 하나 당 쿼리문이 호출되므로 너무 많은 데이터 가공 과정이 발생하여 서버 부담이 커진다는 문제가 있었다. 댓글 목록을 제시 가격 저렴한 순, 센터의 별점 높은 순으로 정렬까지 한 후 반환하므로 업데이트 때마다 실행 시간 부담도 컸다. 따라서 이런 방식에 대해, 댓글 업데이트가 발생하면 모든 댓글 목록을 다시 보내지 않고 변경 사항만 전송하는 방식으로 변경하였다. 댓글 생성과 수정의 경우 변경된 댓글 하나만 데이터를 보내주어 프론트 쪽에서 기존 목록에 반영하고 정렬하여 보여주기로 했다. 댓글 삭제의 경우 삭제된 댓글 아이디만 반환하기로 했다.
2. 웹소켓 세션 저장소는 맵으로 멤버에 해당하는 웹소켓 세션은 오직 하나만 저장할 수 있도록 하였다. 그런데 만약 같은 멤버로 두 개 이상의 화면에서 로그인한다던가, 악의를 가지고 고의로 특정 멤버에 대해 여러 번 웹소켓 연결 요청을 보낸다던가 한다면 이미 유효한 세션이 있는데도 해당 멤버는 새로운 세션으로 갈아끼워져 기존 세션으로는 통신이 되지 않는 문제가 발생할 수 있다고 생각했다. 따라서 웹소켓 세션을 맵에 저장하는 과정에서 그 멤버에 해당하는 기존 세션이 아예 존재하지 않거나, 존재하는데 연결이 종료된 경우에만 새로운 세션을 저장할 수 있게끔 단계를 추가했다.
3. 멀티 쓰레드 환경에 대해 공유자원으로 사용해야되는 ConcurrentHashMap 타입의 세션 저장소 필드를 static으로 선언해야된다는 생각이 들었다. 기본적으로 정적 변수여야 JVM내 method area에 한 번만 저장되어 공유자원이 될 수 있고, 정적 변수가 아니라면 쓰레드마다 생성되는 스택에 따로 생성된다고 알고 있었다. 근데 지금까지 static을 붙이지 않았는데도 여러 번 테스트를 했을 때 문제가 되지 않은 이유가 궁금했다. 
생각해봤더니 이 ConcurrentHashMap 필드를 가지는 WebSocketRepository 클래스는 @Repository 어노테이션을 붙여놔서 스프링이 싱글톤 객체로 관리하는 빈이다. 즉, 해당 클래스의 인스턴스는 오직 하나만 생성되므로 멀티 쓰레드 환경에서도 공유자원으로 사용되는 ConcurrentHashMap 객체 또한 하나만 존재하게 되어 문제되지 않았던 것이다. 
그치만 클래스 수준의 모든 인스턴스에서 공유되는 자원이라는 의미상, static을 붙여줬다.
4. 세션 저장소를 ConcurrentHashMap으로 이용함으로써 멀티 쓰레드 세이프한 세션 접근이 보장되었다. 하지만 여러 쓰레드가 동일한 세션을 이용하여 동시에 데이터를 전송한다고 했을 때, 받는 클라이언트 쪽에서 어떤 데이터를 취해야할 지 혼동이 올 수 있다고 생각했다. 그래서 데이터를 전송하는 메소드 내 이용하는 세션에 synchronized를 걸어, 한번에 하나의 쓰레드만 데이터를 전송할 수 있게끔 하였다.

## 기타
