### PR TITLE
경매 웹소켓 통신 관련, 회원가입 프로필 첨부 관련 수정 #186

### DIFF
--- a/33ma3/src/main/java/softeer/be33ma3/config/WebConfig.java
+++ b/33ma3/src/main/java/softeer/be33ma3/config/WebConfig.java
@@ -33,7 +33,7 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addInterceptor(jwtAuthenticationInterceptor())
                 .order(2)
                 .addPathPatterns("/**")
-                .excludePathPatterns("/client/signUp", "/center/signUp", "/profile/*", "/center/all", "/login", "/location", "/center/all", "/reissue", "/post", "/post/one/*", "/review", "/review/**")
+                .excludePathPatterns("/client/signUp", "/center/signUp", "/center/all", "/login", "/location", "/center/all", "/reissue", "/post", "/post/one/*", "/review", "/review/**")
                 .excludePathPatterns("/swagger-ui/**", "/swagger-resources/**", "/v3/api-docs/**");
     }
 

--- a/33ma3/src/main/java/softeer/be33ma3/controller/MemberController.java
+++ b/33ma3/src/main/java/softeer/be33ma3/controller/MemberController.java
@@ -34,39 +34,27 @@ public class MemberController {
     private final JwtService jwtService;
 
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "회원가입 성공", content = @Content(schema = @Schema(implementation = DataResponse.class))),
+            @ApiResponse(responseCode = "200", description = "회원가입 성공", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
             @ApiResponse(responseCode = "400", description = "이미 존재하는 아이디", content = @Content(schema = @Schema(implementation = SingleResponse.class)))
     })
     @Operation(summary = "일반 사용자 회원가입", description = "사용자 회원가입 메서드 입니다.")
-    @PostMapping("/client/signUp")
-    public ResponseEntity<?> clientSignUp(@RequestBody @Valid ClientSignUpDto clientSignUpDto){
-        Long memberId = memberService.clientSignUp(clientSignUpDto);
-
-        return ResponseEntity.ok(DataResponse.success("회원가입 성공", memberId));
+    @PostMapping(value = "/client/signUp", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    public ResponseEntity<?> clientSignUp(@RequestPart(name = "request") @Valid ClientSignUpDto clientSignUpDto,
+                                          @RequestPart(name = "profile", required = false) MultipartFile profile){
+        memberService.clientSignUp(clientSignUpDto, profile);
+        return ResponseEntity.ok(SingleResponse.success("회원가입 성공"));
     }
 
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "회원가입 성공", content = @Content(schema = @Schema(implementation = DataResponse.class))),
+            @ApiResponse(responseCode = "200", description = "회원가입 성공", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
             @ApiResponse(responseCode = "400", description = "이미 존재하는 아이디", content = @Content(schema = @Schema(implementation = SingleResponse.class)))
     })
     @Operation(summary = "센터 회원가입", description = "센터 회원가입 메서드 입니다.")
-    @PostMapping("/center/signUp")
-    public ResponseEntity<?> centerSignUp(@RequestBody @Valid CenterSignUpDto centerSignUpDto){
-        Long memberId = memberService.centerSignUp(centerSignUpDto);
-
-        return ResponseEntity.ok(DataResponse.success("회원가입 성공",memberId));
-    }
-
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "프로필 사진 저장 성공", content = @Content(schema = @Schema(implementation = SingleResponse.class))),
-            @ApiResponse(responseCode = "404", description = "존재하지 않는 회원", content = @Content(schema = @Schema(implementation = SingleResponse.class)))
-    })
-    @Operation(summary = "프로필 사진 저장", description = "회원가입 시 프로필 사진 저장 메서드 입니다.")
-    @Parameter(name = "member_id", description = "member id", required = true, example = "1", in = ParameterIn.PATH)
-    @PostMapping(value = "/profile/{member_id}", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
-    public ResponseEntity<?> addProfile(@PathVariable("member_id") Long memberId, @RequestPart(name = "profile", required = false) MultipartFile profile) {
-        memberService.addProfile(memberId, profile);
-        return ResponseEntity.ok().body(SingleResponse.success("프로필 사진 저장 성공"));
+    @PostMapping(value = "/center/signUp", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    public ResponseEntity<?> centerSignUp(@RequestPart(name = "request") @Valid CenterSignUpDto centerSignUpDto,
+                                          @RequestPart(name = "profile", required = false) MultipartFile profile){
+        memberService.centerSignUp(centerSignUpDto, profile);
+        return ResponseEntity.ok(SingleResponse.success("회원가입 성공"));
     }
 
     @ApiResponses({

--- a/33ma3/src/main/java/softeer/be33ma3/service/MemberService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/MemberService.java
@@ -69,24 +69,6 @@ public class MemberService {
     }
 
     @Transactional
-    public void addProfile(Long memberId, MultipartFile profile) {
-        // 해당하는 유저 가져오기
-        Member member = memberRepository.findById(memberId).orElseThrow(() -> new BusinessException(NOT_FOUND_MEMBER));
-
-        if(profile.isEmpty()) {
-            if(member.getMemberType() == CENTER_TYPE){
-                Image image = Image.createImage(s3Service.getFileUrl("profile.png"), "profile.png");
-                member.setProfile(imageRepository.save(image));
-            }
-            //TODO: 일반 회원 전용 프로필 이미지 생기면 저장하는 로직 추가하기
-            return;
-        }
-        // 이미지 저장하기
-        Image image = imageService.saveImage(profile);
-        member.setProfile(image);
-    }
-
-    @Transactional
     public LoginSuccessDto login(LoginDto loginDto) {
         Member member = memberRepository.findByLoginIdAndPassword(loginDto.getLoginId(), loginDto.getPassword())
                 .orElseThrow(() -> new BusinessException(ID_PASSWORD_MISMATCH));

--- a/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
@@ -120,7 +120,7 @@ public class OfferService {
         offer.setSelected();
         post.setDone();
         // 6. 서비스 센터들에게 낙찰 또는 경매 마감 메세지 보내기
-        sendMessageAfterSelection(postId, offer.getCenter().getMemberId());
+        sendMessageAfterSelection(postId, post.getMember().getMemberId(), offer.getCenter().getMemberId());
         webSocketService.deletePostRoom(postId);
     }
 
@@ -163,18 +163,18 @@ public class OfferService {
     }
 
     // 낙찰 처리 후 서비스 센터들에게 낙찰 메세지, 경매 마감 메세지 전송
-    private void sendMessageAfterSelection(Long postId, Long selectedMemberId) {
-        // 1. 낙찰된 센터에게 메세지 보내기
+    private void sendMessageAfterSelection(Long postId, Long writerId, Long selectedMemberId) {
         DataResponse<Boolean> selectSuccess = DataResponse.success(SELECT_SUCCESS, true);
-        webSocketService.sendData2Client(selectedMemberId, selectSuccess);
-        // 2. 그 외 관전자들에게 메세지 보내기
         DataResponse<Boolean> selectFail = DataResponse.success(SELECT_FAIL, false);
         DataResponse<Boolean> selectEnd = DataResponse.success(SELECT_END, false);
+        // 낙찰된 센터에게 메세지 보내기
+        webSocketService.sendData2Client(selectedMemberId, selectSuccess);
         // 현재 관전자들
         Set<Long> memberIdsInPost = webSocketService.findAllMemberInPost(postId);
-        // 낙찰에 실패한 서비스 센터들
+        memberIdsInPost.remove(writerId);
+        memberIdsInPost.remove(selectedMemberId);
+        // 경매에 참여한 서비스 센터들
         List<Long> participants = offerRepository.findCenterMemberIdsByPost_PostId(postId);
-        participants.remove(selectedMemberId);
 
         memberIdsInPost.forEach(memberId -> {
             if(participants.contains(memberId)) {

--- a/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
@@ -139,14 +139,16 @@ public class OfferService {
             data = OfferDetailDto.fromEntity(offer, score, offer.getCenter().getImage().getLink());
         }
         // 게시글 작성자에게 데이터 보내기
-        sendData2Writer(post.getMember().getMemberId(), requestType, data);
+        sendData2Writer(post.getPostId(), post.getMember().getMemberId(), requestType, data);
         // 그 외 화면을 보고 있는 유저들에게 평균 제시 가격 보내기
         sendAvgPrice2others(post.getPostId(), post.getMember().getMemberId());
     }
 
-    public void sendData2Writer(Long memberId, String requestType, Object data) {
+    public void sendData2Writer(Long postId, Long memberId, String requestType, Object data) {
         DataResponse<?> response = DataResponse.success(requestType, data);
-        webSocketService.sendData2Client(memberId, response);
+        if(webSocketService.isInPostRoom(postId, memberId)) {
+            webSocketService.sendData2Client(memberId, response);
+        }
     }
 
     public void sendAvgPrice2others(Long postId, Long writerId) {

--- a/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
@@ -17,10 +17,8 @@ import softeer.be33ma3.repository.post.PostRepository;
 import softeer.be33ma3.response.DataResponse;
 import softeer.be33ma3.websocket.WebSocketService;
 
-import java.util.*;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static softeer.be33ma3.exception.ErrorCode.*;
 import static softeer.be33ma3.service.MemberService.CENTER_TYPE;
@@ -39,6 +37,9 @@ public class OfferService {
     private static final String OFFER_CREATE = "CREATE";
     private static final String OFFER_UPDATE = "UPDATE";
     private static final String OFFER_DELETE = "DELETE";
+    private static final String SELECT_SUCCESS = "SELECT SUCCESS";
+    private static final String SELECT_FAIL = "SELECT FAIL";
+    private static final String SELECT_END = "SELECT END";
 
     // 견적 제시 댓글 하나 반환
     public OfferDetailDto showOffer(Long postId, Long offerId) {
@@ -163,14 +164,25 @@ public class OfferService {
 
     // 낙찰 처리 후 서비스 센터들에게 낙찰 메세지, 경매 마감 메세지 전송
     private void sendMessageAfterSelection(Long postId, Long selectedMemberId) {
-        // 낙찰 메세지
-        DataResponse<Boolean> selectAlert = DataResponse.success("제시한 견적이 낙찰되었습니다.", true);
-        webSocketService.sendData2Client(selectedMemberId, selectAlert);
-        // 경매 마감 메세지
-        DataResponse<Boolean> endAlert = DataResponse.success("견적 미선정으로 경매가 마감되었습니다. 다음 기회를 노려보세요!", false);
-        List<Long> memberIdsInPost = offerRepository.findCenterMemberIdsByPost_PostId(postId);
-        memberIdsInPost.stream()
-                .filter(memberId -> !memberId.equals(selectedMemberId))
-                .forEach(memberId -> webSocketService.sendData2Client(memberId, endAlert));
+        // 1. 낙찰된 센터에게 메세지 보내기
+        DataResponse<Boolean> selectSuccess = DataResponse.success(SELECT_SUCCESS, true);
+        webSocketService.sendData2Client(selectedMemberId, selectSuccess);
+        // 2. 그 외 관전자들에게 메세지 보내기
+        DataResponse<Boolean> selectFail = DataResponse.success(SELECT_FAIL, false);
+        DataResponse<Boolean> selectEnd = DataResponse.success(SELECT_END, false);
+        // 현재 관전자들
+        Set<Long> memberIdsInPost = webSocketService.findAllMemberInPost(postId);
+        // 낙찰에 실패한 서비스 센터들
+        List<Long> participants = offerRepository.findCenterMemberIdsByPost_PostId(postId);
+        participants.remove(selectedMemberId);
+
+        memberIdsInPost.forEach(memberId -> {
+            if(participants.contains(memberId)) {
+                webSocketService.sendData2Client(memberId, selectFail);
+            }
+            else {
+                webSocketService.sendData2Client(memberId, selectEnd);
+            }
+        });
     }
 }


### PR DESCRIPTION
## 구현 내용
- [x] 회원가입 과정에서 하나의 api 요청으로 프로필 사진을 같이 첨부할 수 있도록 변경
- [x] 댓글 업데이트시 게시글 작성자가 해당하는 게시글 화면을 보고 있을 때만 변경 사항 실시간 전송
- [x] 댓글 낙찰 처리 시 해당 화면을 보고 있는 모든 유저들에게 실시간 메세지 전송

## 고민 사항
댓글 업데이트가 발생하면 게시글 작성자에게 변경 사항을 실시간 전송하는데, 어떤 화면을 보고 있는지 확인하지 않고 웹소켓 연결이 되어있으면 바로 데이터를 전송하는 식으로 개발했더니 해당 유저가 다른 게시글을 보고 있을 때 변경사항이 화면에 띄워지는 문제가 발생했다.
그래서 글 작성자가 변경이 일어난 해당 게시글 화면에 진입해있는지 먼저 파악한 뒤 데이터를 전송하는 방식으로 수정하였다.
근데 만약 데이터 전송 시도와 글 작성자가 화면을 빠져나오는 일이 동시에 일어나면 문제가 되진 않을지 생각이 들었다.
작성자가 해당 화면에 있는지 검증할 때는 true가 반환되었는데 그와 동시에 작성자가 바로 화면을 벗어나 다른 게시글 화면으로 들어가면, 데이터 전송이 엉뚱한 게시글 화면으로 반영되진 않을까 싶었다. 물론 인간이 컴퓨터의 속도보다 더 빠르게 화면 전환을 할 것 같진 않지만... 서버 속도가 느려져서 딜레이가 될 수도 있겠다는 생각이 들었다.
이런 문제를 방지하기 위해 댓글 세부사항 데이터를 보내줄 때 해당 댓글이 어떤 게시글에 속해있는지 post id 필드를 추가하여 프론트에 보내주고, 프론트는 이 post id가 보고있는 게시글의 id와 먼저 대조하여 일치할 때만 띄워주는 방식으로 하기로 했다. 
일단 현재 상황으로써는 급한 수정 사항이 아니므로 시간이 나면 그런 방향으로 수정하기로 했다.

## 기타
