### PR TITLE
게시글, 챗 서비스 관련 리팩토링 #146

### DIFF
--- a/33ma3/src/main/java/softeer/be33ma3/domain/Center.java
+++ b/33ma3/src/main/java/softeer/be33ma3/domain/Center.java
@@ -20,7 +20,7 @@ public class Center {
 
     private double longitude;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 

--- a/33ma3/src/main/java/softeer/be33ma3/domain/ChatMessage.java
+++ b/33ma3/src/main/java/softeer/be33ma3/domain/ChatMessage.java
@@ -10,11 +10,11 @@ public class ChatMessage extends BaseTimeEntity{
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long chatMessageId;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "sender_id")
     private Member sender;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "chat_room_id")
     private ChatRoom chatRoom;
 

--- a/33ma3/src/main/java/softeer/be33ma3/domain/ChatRoom.java
+++ b/33ma3/src/main/java/softeer/be33ma3/domain/ChatRoom.java
@@ -10,11 +10,11 @@ public class ChatRoom extends BaseTimeEntity{
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long chatRoomId;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "center_id")
     private Member center;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "client_id")
     private Member client;
 

--- a/33ma3/src/main/java/softeer/be33ma3/domain/Image.java
+++ b/33ma3/src/main/java/softeer/be33ma3/domain/Image.java
@@ -17,7 +17,7 @@ public class Image {
 
     private String fileName;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
     private Post post;
 

--- a/33ma3/src/main/java/softeer/be33ma3/domain/Member.java
+++ b/33ma3/src/main/java/softeer/be33ma3/domain/Member.java
@@ -18,7 +18,7 @@ public class Member {
 
     private String password;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "image_id")
     private Image image;
 

--- a/33ma3/src/main/java/softeer/be33ma3/domain/Member.java
+++ b/33ma3/src/main/java/softeer/be33ma3/domain/Member.java
@@ -9,6 +9,9 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member {
+    private static final int CLIENT_TYPE = 1;
+    private static final int CENTER_TYPE = 2;
+
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long memberId;
 
@@ -30,8 +33,12 @@ public class Member {
         this.password = password;
     }
 
-    public static Member createMember(int memberType, String loginId, String password){
-        return new Member(memberType, loginId, password);
+    public static Member createClient(String loginId, String password){
+        return new Member(CLIENT_TYPE, loginId, password);
+    }
+
+    public static Member createCenter(String loginId, String password){
+        return new Member(CENTER_TYPE, loginId, password);
     }
 
     public void setRefreshToken(String refreshToken) {
@@ -40,5 +47,13 @@ public class Member {
 
     public void setProfile(Image image) {
         this.image = image;
+    }
+
+    public boolean isClient(){
+        return memberType == CLIENT_TYPE;
+    }
+
+    public boolean isCenter(){
+        return memberType == CENTER_TYPE;
     }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/domain/Offer.java
+++ b/33ma3/src/main/java/softeer/be33ma3/domain/Offer.java
@@ -20,11 +20,11 @@ public class Offer {
 
     private boolean selected;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
     private Post post;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "center_id")
     private Member center;
 

--- a/33ma3/src/main/java/softeer/be33ma3/domain/Offer.java
+++ b/33ma3/src/main/java/softeer/be33ma3/domain/Offer.java
@@ -45,4 +45,9 @@ public class Offer {
     public void setSelected() {
         selected = true;
     }
+
+    public void setPost(Post post){
+        this.post = post;
+        post.getOffers().add(this);
+    }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/domain/Post.java
+++ b/33ma3/src/main/java/softeer/be33ma3/domain/Post.java
@@ -35,8 +35,11 @@ public class Post extends BaseTimeEntity{
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @OneToMany(mappedBy = "post")
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Image> images = new ArrayList<>();
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Offer> offers = new ArrayList<>();
 
     //셍성 메소드
     public static Post createPost(PostCreateDto postCreateDto, Region region, Member member) {
@@ -66,10 +69,5 @@ public class Post extends BaseTimeEntity{
         this.repairService = postCreateDto.getRepairService();
         this.tuneUpService = postCreateDto.getTuneUpService();
         this.region = region;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        return super.equals(obj);
     }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/domain/Post.java
+++ b/33ma3/src/main/java/softeer/be33ma3/domain/Post.java
@@ -27,11 +27,11 @@ public class Post extends BaseTimeEntity{
 
     private String tuneUpService;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "region_id")
     private Region region;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 

--- a/33ma3/src/main/java/softeer/be33ma3/domain/PostPerCenter.java
+++ b/33ma3/src/main/java/softeer/be33ma3/domain/PostPerCenter.java
@@ -13,11 +13,11 @@ public class PostPerCenter {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long postPerCenterId;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "center_id")
     private Center center;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
     private Post post;
 

--- a/33ma3/src/main/java/softeer/be33ma3/domain/Review.java
+++ b/33ma3/src/main/java/softeer/be33ma3/domain/Review.java
@@ -18,15 +18,15 @@ public class Review extends BaseTimeEntity{
 
     private double score;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
     private Post post;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "writer_id")
     private Member writer;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "center_id")
     private Member center;
 

--- a/33ma3/src/main/java/softeer/be33ma3/dto/response/LastMessageDto.java
+++ b/33ma3/src/main/java/softeer/be33ma3/dto/response/LastMessageDto.java
@@ -1,0 +1,13 @@
+package softeer.be33ma3.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+public class LastMessageDto {
+    private String message;
+    private LocalDateTime createTime;
+}

--- a/33ma3/src/main/java/softeer/be33ma3/dto/response/OfferDetailDto.java
+++ b/33ma3/src/main/java/softeer/be33ma3/dto/response/OfferDetailDto.java
@@ -34,7 +34,7 @@ public class OfferDetailDto implements Comparable<OfferDetailDto> {
     private String profile;
 
     // Offer Entity -> OfferDetailDto 변환
-    public static OfferDetailDto fromEntity(Offer offer, Double score, String profile) {
+    public static OfferDetailDto fromEntity(Offer offer, Double score) {
         return OfferDetailDto.builder()
                 .offerId(offer.getOfferId())
                 .memberId(offer.getCenter().getMemberId())
@@ -43,7 +43,7 @@ public class OfferDetailDto implements Comparable<OfferDetailDto> {
                 .contents(offer.getContents())
                 .selected(offer.isSelected())
                 .score(score)
-                .profile(profile).build();
+                .profile(offer.getCenter().getImage().getLink()).build();
     }
 
     // 제시 가격 저렴한 순 -> 별점 높은 순 정렬

--- a/33ma3/src/main/java/softeer/be33ma3/dto/response/PostDetailDto.java
+++ b/33ma3/src/main/java/softeer/be33ma3/dto/response/PostDetailDto.java
@@ -10,6 +10,8 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static softeer.be33ma3.utils.StringParser.stringCommaParsing;
+
 @Builder
 @Getter
 @Schema(description = "게시글 상세보기 응답 DTO")
@@ -48,7 +50,7 @@ public class PostDetailDto {
     private List<String> imageList;
 
     // Post Entity -> PostDetailDto 변환
-    public static PostDetailDto fromEntity(Post post, List<String> repairList, List<String> tuneUpList) {
+    public static PostDetailDto fromEntity(Post post) {
         List<String> imageList = post.getImages().stream().map(Image::getLink).toList();
         Duration duration = calculateDuration(post);
         int dDay = -1;
@@ -67,8 +69,8 @@ public class PostDetailDto {
                 .remainTime(remainTime)
                 .regionName(post.getRegion().getRegionName())
                 .contents(post.getContents())
-                .repairList(repairList)
-                .tuneUpList(tuneUpList)
+                .repairList(stringCommaParsing(post.getRepairService()))
+                .tuneUpList(stringCommaParsing(post.getTuneUpService()))
                 .imageList(imageList).build();
     }
 

--- a/33ma3/src/main/java/softeer/be33ma3/dto/response/PostThumbnailDto.java
+++ b/33ma3/src/main/java/softeer/be33ma3/dto/response/PostThumbnailDto.java
@@ -11,6 +11,8 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 
+import static softeer.be33ma3.utils.StringParser.stringCommaParsing;
+
 @Getter
 @Builder
 @Schema(description = "게시글 목록 미리보기 응답 DTO")
@@ -43,7 +45,7 @@ public class PostThumbnailDto {
     private int offerCount;
 
     // Post Entity -> PostThumbnailDto 변환
-    public static PostThumbnailDto fromEntity(Post post, List<String> repairList, List<String> tuneUpList, int offerCount) {
+    public static PostThumbnailDto fromEntity(Post post) {
         List<String> imageList = post.getImages().stream().map(Image::getLink).toList();
         Duration duration = PostDetailDto.calculateDuration(post);
         int dDay = -1;
@@ -56,10 +58,10 @@ public class PostThumbnailDto {
                 .modelName(post.getModelName())
                 .createTime(createTimeFormatting(post.getCreateTime()))
                 .dDay(dDay)
-                .repairList(repairList)
-                .tuneUpList(tuneUpList)
+                .repairList(stringCommaParsing(post.getRepairService()))
+                .tuneUpList(stringCommaParsing(post.getTuneUpService()))
                 .imageList(imageList)
-                .offerCount(offerCount).build();
+                .offerCount(post.getOffers().size()).build();
     }
 
     private static String createTimeFormatting(LocalDateTime rawCreateTime) {

--- a/33ma3/src/main/java/softeer/be33ma3/repository/Chat/ChatMessageCustomRepository.java
+++ b/33ma3/src/main/java/softeer/be33ma3/repository/Chat/ChatMessageCustomRepository.java
@@ -1,0 +1,7 @@
+package softeer.be33ma3.repository.Chat;
+
+import softeer.be33ma3.dto.response.LastMessageDto;
+
+public interface ChatMessageCustomRepository {
+    LastMessageDto findLastMessageByChatRoomId(Long chatRoomId);
+}

--- a/33ma3/src/main/java/softeer/be33ma3/repository/Chat/ChatMessageCustomRepositoryImpl.java
+++ b/33ma3/src/main/java/softeer/be33ma3/repository/Chat/ChatMessageCustomRepositoryImpl.java
@@ -1,0 +1,29 @@
+package softeer.be33ma3.repository.Chat;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import softeer.be33ma3.dto.response.LastMessageDto;
+
+import static softeer.be33ma3.domain.QChatMessage.chatMessage;
+
+@Repository
+@RequiredArgsConstructor
+public class ChatMessageCustomRepositoryImpl implements ChatMessageCustomRepository{
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public LastMessageDto findLastMessageByChatRoomId(Long chatRoomId) {
+        LastMessageDto lastMessage = jpaQueryFactory
+                .select(Projections.constructor(LastMessageDto.class,
+                        chatMessage.contents,
+                        chatMessage.createTime))
+                .from(chatMessage)
+                .where(chatMessage.chatRoom.chatRoomId.eq(chatRoomId))
+                .orderBy(chatMessage.createTime.desc())
+                .fetchFirst();
+
+        return lastMessage;
+    }
+}

--- a/33ma3/src/main/java/softeer/be33ma3/repository/Chat/ChatMessageRepository.java
+++ b/33ma3/src/main/java/softeer/be33ma3/repository/Chat/ChatMessageRepository.java
@@ -1,4 +1,4 @@
-package softeer.be33ma3.repository;
+package softeer.be33ma3.repository.Chat;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -7,12 +7,9 @@ import softeer.be33ma3.domain.ChatMessage;
 
 import java.util.List;
 
-public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long>, ChatMessageCustomRepository{
     @Query("SELECT COALESCE(COUNT(c), 0) FROM ChatMessage c WHERE c.chatRoom.chatRoomId = :chatRoomId AND c.readDone = false AND c.sender.memberId != :memberId")
     long countReadDoneIsFalse(@Param("chatRoomId") Long chatRoomId, @Param("memberId") Long memberId);  //내가 아닌 다른 사람이 보낸 경우 읽음이 false 인 개수
-
-    @Query("SELECT c FROM ChatMessage c WHERE c.chatRoom.chatRoomId = :chatRoomId ORDER BY c.createTime DESC LIMIT 1")
-    ChatMessage findLastMessageByChatRoomId(@Param("chatRoomId") Long chatRoomId);
 
     List<ChatMessage> findByChatRoom_ChatRoomId(Long roomId);
 }

--- a/33ma3/src/main/java/softeer/be33ma3/repository/Chat/ChatRoomRepository.java
+++ b/33ma3/src/main/java/softeer/be33ma3/repository/Chat/ChatRoomRepository.java
@@ -1,4 +1,4 @@
-package softeer.be33ma3.repository;
+package softeer.be33ma3.repository.Chat;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;

--- a/33ma3/src/main/java/softeer/be33ma3/repository/review/ReviewRepository.java
+++ b/33ma3/src/main/java/softeer/be33ma3/repository/review/ReviewRepository.java
@@ -8,7 +8,7 @@ import softeer.be33ma3.domain.Review;
 import java.util.List;
 import java.util.Optional;
 
-public interface ReviewRepository extends JpaRepository<Review, Long> {
+public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewCustomRepository {
     Optional<Review> findByPost_PostId(Long postId);
 
     @Query("SELECT AVG(r.score) FROM Review r WHERE r.center.memberId = :memberId")

--- a/33ma3/src/main/java/softeer/be33ma3/service/ChatService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/ChatService.java
@@ -106,15 +106,15 @@ public class ChatService {
     }
 
     private void sendDirectToReceiver(ChatMessage savedChatMessage, ChatRoom chatRoom, Member sender, Member receiver) {
-//        AllChatRoomDto chatDto = getChatDto(chatRoom, receiver.getLoginId(), sender); //sender 한테 전송할 목록
-//        webSocketService.sendAllChatData2Client(sender.getMemberId(), chatDto);  //목록 실시간 전송
+        AllChatRoomDto chatDto = getChatDto(chatRoom, receiver.getLoginId(), sender); //sender 한테 전송할 목록
+        webSocketService.sendAllChatData2Client(sender.getMemberId(), chatDto);  //목록 실시간 전송
 
         savedChatMessage.setReadDoneTrue();   //읽음 처리
 
         //receiver 에게 전송
         ChatMessageResponseDto chatMessageResponseDto = ChatMessageResponseDto.create(savedChatMessage);
-//        chatDto = getChatDto(chatRoom, sender.getLoginId(), receiver);     //전송할 목록 생성
-//        webSocketService.sendAllChatData2Client(receiver.getMemberId(), chatDto);   //목록 실시간 전송
+        chatDto = getChatDto(chatRoom, sender.getLoginId(), receiver);     //전송할 목록 생성
+        webSocketService.sendAllChatData2Client(receiver.getMemberId(), chatDto);   //목록 실시간 전송
         webSocketService.sendData2Client(receiver.getMemberId(), chatMessageResponseDto);   //채팅 내용 실시간 전송
     }
 

--- a/33ma3/src/main/java/softeer/be33ma3/service/ChatService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/ChatService.java
@@ -12,8 +12,11 @@ import softeer.be33ma3.dto.request.ChatMessageDto;
 import softeer.be33ma3.dto.response.ChatHistoryDto;
 import softeer.be33ma3.dto.response.AllChatRoomDto;
 import softeer.be33ma3.dto.response.ChatMessageResponseDto;
+import softeer.be33ma3.dto.response.LastMessageDto;
 import softeer.be33ma3.exception.BusinessException;
 import softeer.be33ma3.repository.*;
+import softeer.be33ma3.repository.Chat.ChatMessageRepository;
+import softeer.be33ma3.repository.Chat.ChatRoomRepository;
 import softeer.be33ma3.repository.post.PostRepository;
 import softeer.be33ma3.websocket.WebSocketRepository;
 import softeer.be33ma3.websocket.WebSocketService;
@@ -116,12 +119,12 @@ public class ChatService {
     }
 
     private AllChatRoomDto getChatDto(ChatRoom chatRoom, String memberName, Member member) {
-        ChatMessage lastChatMessage = chatMessageRepository.findLastMessageByChatRoomId(chatRoom.getChatRoomId());//마지막 메세지
-        if(lastChatMessage == null){    //방이 만들어지고 메세지를 보내지 않은 경우
+        LastMessageDto lastMessage = chatMessageRepository.findLastMessageByChatRoomId(chatRoom.getChatRoomId());//마지막 메세지
+        if(lastMessage == null){    //방이 만들어지고 메세지를 보내지 않은 경우
             return AllChatRoomDto.create(chatRoom, "", memberName, 0, "");
         }
         int count = (int) chatMessageRepository.countReadDoneIsFalse(chatRoom.getChatRoomId(), member.getMemberId());     //안읽은 메세지 개수
-        return AllChatRoomDto.create(chatRoom, lastChatMessage.getContents(), memberName, count, createTimeParsing(lastChatMessage.getCreateTime()));
+        return AllChatRoomDto.create(chatRoom, lastMessage.getMessage(), memberName, count, createTimeParsing(lastMessage.getCreateTime()));
     }
 
     @Transactional

--- a/33ma3/src/main/java/softeer/be33ma3/service/ChatService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/ChatService.java
@@ -106,15 +106,15 @@ public class ChatService {
     }
 
     private void sendDirectToReceiver(ChatMessage savedChatMessage, ChatRoom chatRoom, Member sender, Member receiver) {
-        AllChatRoomDto chatDto = getChatDto(chatRoom, receiver.getLoginId(), sender); //sender 한테 전송할 목록
-        webSocketService.sendAllChatData2Client(sender.getMemberId(), chatDto);  //목록 실시간 전송
+//        AllChatRoomDto chatDto = getChatDto(chatRoom, receiver.getLoginId(), sender); //sender 한테 전송할 목록
+//        webSocketService.sendAllChatData2Client(sender.getMemberId(), chatDto);  //목록 실시간 전송
 
         savedChatMessage.setReadDoneTrue();   //읽음 처리
 
         //receiver 에게 전송
         ChatMessageResponseDto chatMessageResponseDto = ChatMessageResponseDto.create(savedChatMessage);
-        chatDto = getChatDto(chatRoom, sender.getLoginId(), receiver);     //전송할 목록 생성
-        webSocketService.sendAllChatData2Client(receiver.getMemberId(), chatDto);   //목록 실시간 전송
+//        chatDto = getChatDto(chatRoom, sender.getLoginId(), receiver);     //전송할 목록 생성
+//        webSocketService.sendAllChatData2Client(receiver.getMemberId(), chatDto);   //목록 실시간 전송
         webSocketService.sendData2Client(receiver.getMemberId(), chatMessageResponseDto);   //채팅 내용 실시간 전송
     }
 

--- a/33ma3/src/main/java/softeer/be33ma3/service/ChatService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/ChatService.java
@@ -26,8 +26,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static softeer.be33ma3.exception.ErrorCode.*;
-import static softeer.be33ma3.service.MemberService.CENTER_TYPE;
-import static softeer.be33ma3.service.MemberService.CLIENT_TYPE;
 import static softeer.be33ma3.utils.StringParser.createTimeParsing;
 
 @Service
@@ -62,13 +60,13 @@ public class ChatService {
     public List<AllChatRoomDto> showAllChatRoom(Member member) {
         List<AllChatRoomDto> allChatRoomDto = new ArrayList<>();
 
-        if(member.getMemberType() == CLIENT_TYPE){
+        if(member.isClient()){
             List<ChatRoom> chatRooms = chatRoomRepository.findByClient_MemberId(member.getMemberId());
             for (ChatRoom chatRoom : chatRooms) {
                 allChatRoomDto.add(getChatDto(chatRoom, chatRoom.getCenter().getLoginId(), member));
             }
         }
-        if(member.getMemberType() == CENTER_TYPE) {
+        if(member.isCenter()) {
             List<ChatRoom> chatRooms = chatRoomRepository.findByCenter_MemberId(member.getMemberId());
             for (ChatRoom chatRoom : chatRooms) {
                 allChatRoomDto.add(getChatDto(chatRoom, chatRoom.getClient().getLoginId(), member));
@@ -82,40 +80,37 @@ public class ChatService {
     public void sendChatMessage(TextMessage message) throws IOException {
         ChatMessageDto chatMessageDto = getChatMessageDto(message);
 
-        Member sender = memberRepository.findById(chatMessageDto.getSenderId()).get();
-        Member receiver = memberRepository.findById(chatMessageDto.getReceiverId()).get();
-        ChatRoom chatRoom = chatRoomRepository.findById(chatMessageDto.getRoomId()).get();
-
+        Member sender = memberRepository.findById(chatMessageDto.getSenderId()).orElseThrow(() -> new BusinessException(NOT_FOUND_MEMBER));
+        Member receiver = memberRepository.findById(chatMessageDto.getReceiverId()).orElseThrow(() -> new BusinessException(NOT_FOUND_MEMBER));
+        ChatRoom chatRoom = chatRoomRepository.findById(chatMessageDto.getRoomId()).orElseThrow(() -> new BusinessException(NOT_FOUND_CHAT_ROOM));
+        //메세지 저장
         ChatMessage chatMessage = ChatMessage.createChatMessage(sender, chatRoom, chatMessageDto.getMessage());
         ChatMessage savedChatMessage = chatMessageRepository.save(chatMessage);
 
-        if(!webSocketRepository.isMemberInChatRoom(chatRoom.getChatRoomId(), receiver.getMemberId())){      //채팅룸에 상대방이 존재하지 않을 경우
-            if(webSocketRepository.findAllChatRoomSessionByMemberId(receiver.getMemberId()) != null){   //목록 세션에 있는 경우
-                AllChatRoomDto chatDto = getChatDto(chatRoom, sender.getLoginId(), receiver);     //업데이트 할 목록 생성
-                webSocketService.sendAllChatData2Client(receiver.getMemberId(), chatDto);   //실시간 전송 - 채팅 목록
-                return;
-            }
-            return;
+        if(webSocketRepository.isMemberInChatRoom(chatRoom.getChatRoomId(), receiver.getMemberId())){   //상대방이 채팅방 소켓에 연결된 경우
+            savedChatMessage.setReadDoneTrue();   //읽음 처리
+            updateAllChatRoom(chatRoom, receiver, sender);    //보낸 사람 목록 - 실시간 업데이트
+            directSendCahtMessage(savedChatMessage, receiver);  //채팅 내용 실시간 전송
         }
-        sendDirectToReceiver(savedChatMessage, chatRoom, sender, receiver);     //채팅방에 상대방이 존재하는 경우
+        if(webSocketRepository.findAllChatRoomSessionByMemberId(receiver.getMemberId()) != null){   //상대방이 목록 소켓에 연결된 경우
+            //receiver 에게 전송
+            updateAllChatRoom(chatRoom, sender, receiver);    //받는 사람 목록 - 실시간 업데이트
+        }
+    }
+
+    private void directSendCahtMessage(ChatMessage savedChatMessage, Member receiver) {
+        ChatMessageResponseDto chatMessageResponseDto = ChatMessageResponseDto.create(savedChatMessage);
+        webSocketService.sendData2Client(receiver.getMemberId(), chatMessageResponseDto);
+    }
+
+    private void updateAllChatRoom(ChatRoom chatRoom, Member receiver, Member sender) {
+        AllChatRoomDto chatDto = getChatDto(chatRoom, receiver.getLoginId(), sender); //전송할 목록 생성
+        webSocketService.sendAllChatData2Client(sender.getMemberId(), chatDto);  //목록 실시간 전송
     }
 
     private ChatMessageDto getChatMessageDto(TextMessage message) throws JsonProcessingException {
         String payload = message.getPayload();
         return objectMapper.readValue(payload, ChatMessageDto.class);   //payload -> chatMessageDto 로 변환
-    }
-
-    private void sendDirectToReceiver(ChatMessage savedChatMessage, ChatRoom chatRoom, Member sender, Member receiver) {
-        AllChatRoomDto chatDto = getChatDto(chatRoom, receiver.getLoginId(), sender); //sender 한테 전송할 목록
-        webSocketService.sendAllChatData2Client(sender.getMemberId(), chatDto);  //목록 실시간 전송
-
-        savedChatMessage.setReadDoneTrue();   //읽음 처리
-
-        //receiver 에게 전송
-        ChatMessageResponseDto chatMessageResponseDto = ChatMessageResponseDto.create(savedChatMessage);
-        chatDto = getChatDto(chatRoom, sender.getLoginId(), receiver);     //전송할 목록 생성
-        webSocketService.sendAllChatData2Client(receiver.getMemberId(), chatDto);   //목록 실시간 전송
-        webSocketService.sendData2Client(receiver.getMemberId(), chatMessageResponseDto);   //채팅 내용 실시간 전송
     }
 
     private AllChatRoomDto getChatDto(ChatRoom chatRoom, String memberName, Member member) {
@@ -146,11 +141,11 @@ public class ChatService {
     }
 
     private void isValidRoomMember(Member member, ChatRoom chatRoom) {
-        if (member.getMemberType() == CLIENT_TYPE && !chatRoom.getClient().equals(member)) {
+        if (member.isClient() && !chatRoom.getClient().equals(member)) {
             throw new BusinessException(NOT_A_MEMBER_OF_ROOM);
         }
 
-        if (member.getMemberType() == CENTER_TYPE && !chatRoom.getCenter().equals(member)) {
+        if (member.isCenter() && !chatRoom.getCenter().equals(member)) {
             throw new BusinessException(NOT_A_MEMBER_OF_ROOM);
         }
     }

--- a/33ma3/src/main/java/softeer/be33ma3/service/MemberService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/MemberService.java
@@ -25,9 +25,6 @@ import static softeer.be33ma3.exception.ErrorCode.*;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class MemberService {
-    public static final int CLIENT_TYPE = 1;
-    public static final int CENTER_TYPE = 2;
-
     private final MemberRepository memberRepository;
     private final CenterRepository centerRepository;
     private final JwtService jwtService;
@@ -41,7 +38,7 @@ public class MemberService {
             throw new BusinessException(DUPLICATE_ID);
         }
 
-        Member member = Member.createMember(CLIENT_TYPE, clientSignUpDto.getLoginId(), clientSignUpDto.getPassword());
+        Member member = Member.createClient(clientSignUpDto.getLoginId(), clientSignUpDto.getPassword());
         return memberRepository.save(member).getMemberId();
     }
 
@@ -51,7 +48,7 @@ public class MemberService {
             throw new BusinessException(DUPLICATE_ID);
         }
 
-        Member member = Member.createMember(CENTER_TYPE, centerSignUpDto.getLoginId(), centerSignUpDto.getPassword());
+        Member member = Member.createCenter(centerSignUpDto.getLoginId(), centerSignUpDto.getPassword());
         Member savedMember = memberRepository.save(member);
 
         Center center = Center.createCenter(centerSignUpDto.getLatitude(), centerSignUpDto.getLongitude(), savedMember);
@@ -65,7 +62,7 @@ public class MemberService {
         Member member = memberRepository.findById(memberId).orElseThrow(() -> new BusinessException(NOT_FOUND_MEMBER));
 
         if(profile.isEmpty()) {
-            if(member.getMemberType() == CENTER_TYPE){
+            if(member.isCenter()){
                 Image image = Image.createImage(s3Service.getFileUrl("profile.png"), "profile.png");
                 member.setProfile(imageRepository.save(image));
             }

--- a/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
@@ -17,10 +17,8 @@ import softeer.be33ma3.repository.post.PostRepository;
 import softeer.be33ma3.response.DataResponse;
 import softeer.be33ma3.websocket.WebSocketService;
 
-import java.util.*;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static softeer.be33ma3.exception.ErrorCode.*;
 import static softeer.be33ma3.service.MemberService.CENTER_TYPE;
@@ -39,6 +37,9 @@ public class OfferService {
     private static final String OFFER_CREATE = "CREATE";
     private static final String OFFER_UPDATE = "UPDATE";
     private static final String OFFER_DELETE = "DELETE";
+    private static final String SELECT_SUCCESS = "SELECT SUCCESS";
+    private static final String SELECT_FAIL = "SELECT FAIL";
+    private static final String SELECT_END = "SELECT END";
 
     // 견적 제시 댓글 하나 반환
     public OfferDetailDto showOffer(Long postId, Long offerId) {
@@ -66,6 +67,7 @@ public class OfferService {
         Offer savedOffer = offerRepository.save(offer);
         // 4. 업데이트된 사항 실시간 전송
         sendAboutOfferUpdate(post, OFFER_CREATE, savedOffer);
+        offer.setPost(post);
         return savedOffer.getOfferId();
     }
 
@@ -119,7 +121,7 @@ public class OfferService {
         offer.setSelected();
         post.setDone();
         // 6. 서비스 센터들에게 낙찰 또는 경매 마감 메세지 보내기
-        sendMessageAfterSelection(postId, offer.getCenter().getMemberId());
+        sendMessageAfterSelection(postId, post.getMember().getMemberId(), offer.getCenter().getMemberId());
         webSocketService.deletePostRoom(postId);
     }
 
@@ -138,14 +140,16 @@ public class OfferService {
             data = OfferDetailDto.fromEntity(offer, score, offer.getCenter().getImage().getLink());
         }
         // 게시글 작성자에게 데이터 보내기
-        sendData2Writer(post.getMember().getMemberId(), requestType, data);
+        sendData2Writer(post.getPostId(), post.getMember().getMemberId(), requestType, data);
         // 그 외 화면을 보고 있는 유저들에게 평균 제시 가격 보내기
         sendAvgPrice2others(post.getPostId(), post.getMember().getMemberId());
     }
 
-    public void sendData2Writer(Long memberId, String requestType, Object data) {
+    public void sendData2Writer(Long postId, Long memberId, String requestType, Object data) {
         DataResponse<?> response = DataResponse.success(requestType, data);
-        webSocketService.sendData2Client(memberId, response);
+        if(webSocketService.isInPostRoom(postId, memberId)) {
+            webSocketService.sendData2Client(memberId, response);
+        }
     }
 
     public void sendAvgPrice2others(Long postId, Long writerId) {
@@ -154,6 +158,8 @@ public class OfferService {
         AvgPriceDto avgPriceDto = new AvgPriceDto(Math.round( avgPrice * 10 ) / 10.0);
         // 해당 화면을 보고 있는 유저 명단 가져오기
         Set<Long> memberList = webSocketService.findAllMemberInPost(postId);
+        if(memberList == null)
+            return;
         memberList.forEach(memberId -> {
             if(!memberId.equals(writerId)) {
                 webSocketService.sendData2Client(memberId, avgPriceDto);
@@ -162,15 +168,27 @@ public class OfferService {
     }
 
     // 낙찰 처리 후 서비스 센터들에게 낙찰 메세지, 경매 마감 메세지 전송
-    private void sendMessageAfterSelection(Long postId, Long selectedMemberId) {
-        // 낙찰 메세지
-        DataResponse<Boolean> selectAlert = DataResponse.success("제시한 견적이 낙찰되었습니다.", true);
-        webSocketService.sendData2Client(selectedMemberId, selectAlert);
-        // 경매 마감 메세지
-        DataResponse<Boolean> endAlert = DataResponse.success("견적 미선정으로 경매가 마감되었습니다. 다음 기회를 노려보세요!", false);
-        List<Long> memberIdsInPost = offerRepository.findCenterMemberIdsByPost_PostId(postId);
-        memberIdsInPost.stream()
-                .filter(memberId -> !memberId.equals(selectedMemberId))
-                .forEach(memberId -> webSocketService.sendData2Client(memberId, endAlert));
+    private void sendMessageAfterSelection(Long postId, Long writerId, Long selectedMemberId) {
+        DataResponse<Boolean> selectSuccess = DataResponse.success(SELECT_SUCCESS, true);
+        DataResponse<Boolean> selectFail = DataResponse.success(SELECT_FAIL, false);
+        DataResponse<Boolean> selectEnd = DataResponse.success(SELECT_END, false);
+        // 낙찰된 센터에게 메세지 보내기
+        webSocketService.sendData2Client(selectedMemberId, selectSuccess);
+        // 현재 관전자들
+        Set<Long> memberIdsInPost = webSocketService.findAllMemberInPost(postId);
+        if(memberIdsInPost == null)
+            return;
+        memberIdsInPost.remove(writerId);
+        memberIdsInPost.remove(selectedMemberId);
+        // 경매에 참여한 서비스 센터들
+        List<Long> participants = offerRepository.findCenterMemberIdsByPost_PostId(postId);
+        memberIdsInPost.forEach(memberId -> {
+            if(participants.contains(memberId)) {
+                webSocketService.sendData2Client(memberId, selectFail);
+            }
+            else {
+                webSocketService.sendData2Client(memberId, selectEnd);
+            }
+        });
     }
 }

--- a/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Set;
 
 import static softeer.be33ma3.exception.ErrorCode.*;
-import static softeer.be33ma3.service.MemberService.CENTER_TYPE;
 
 @Service
 @RequiredArgsConstructor
@@ -56,7 +55,7 @@ public class OfferService {
     public Long createOffer(Long postId, OfferCreateDto offerCreateDto, Member member) {
         // 1. 해당 게시글이 마감 전인지 확인
         Post post = checkNotDonePost(postId);
-        if(member.getMemberType() != CENTER_TYPE) {
+        if(!member.isCenter()) {
             throw new BusinessException(NOT_CENTER);
         }
         // 2. 이미 견적을 작성한 센터인지 검증
@@ -136,7 +135,7 @@ public class OfferService {
         Object data = offer.getOfferId();
         if(!requestType.equals(OFFER_DELETE)) {
             Double score = reviewRepository.findAvgScoreByCenterId(offer.getCenter().getMemberId()).orElse(0.0);
-            data = OfferDetailDto.fromEntity(offer, score, offer.getCenter().getImage().getLink());
+            data = OfferDetailDto.fromEntity(offer, score);
         }
         // 게시글 작성자에게 데이터 보내기
         sendData2Writer(post.getPostId(), post.getMember().getMemberId(), requestType, data);

--- a/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/OfferService.java
@@ -48,8 +48,7 @@ public class OfferService {
         // 2. 해당 댓글 가져오기
         Offer offer = offerRepository.findByPost_PostIdAndOfferId(postId, offerId).orElseThrow(() -> new BusinessException(NOT_FOUND_OFFER));
         Double score = reviewRepository.findAvgScoreByCenterId(offer.getCenter().getMemberId()).orElse(0.0);
-        String profile = offer.getCenter().getImage().getLink();
-        return OfferDetailDto.fromEntity(offer, score, profile);
+        return OfferDetailDto.fromEntity(offer, score);
     }
 
     // 견적 제시 댓글 생성

--- a/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
@@ -43,7 +43,7 @@ public class PostService {
         List<String> repairs = stringCommaParsing(repair);
         List<String> tuneUps = stringCommaParsing(tuneUp);
         List<Long> postIds = null;
-        if(member != null && member.getMemberType() == CENTER_TYPE) {
+        if(member != null && member.getMemberType() == CENTER_TYPE) {   //센터인 경ㅇ
             Center center = centerRepository.findByMember_MemberId(member.getMemberId()).orElseThrow(() -> new BusinessException(NOT_FOUND_CENTER));
             postIds = postPerCenterRepository.findPostIdsByCenterId(center.getCenterId());
         }
@@ -57,18 +57,8 @@ public class PostService {
 
     // List<Post> -> List<PostThumbnailDto>로 변환
     private List<PostThumbnailDto> fromPostList(List<Post> posts) {
-        return new ArrayList<>(posts.stream()
-                .map(post -> {
-                    List<String> repairList = stringCommaParsing(post.getRepairService());
-                    List<String> tuneUpList = stringCommaParsing(post.getTuneUpService());
-                    int offerCount = countOfferNum(post.getPostId());
-                    return PostThumbnailDto.fromEntity(post, repairList, tuneUpList, offerCount);
-                }).toList());
-    }
-
-    // 해당 게시글에 달린 댓글 개수 반환
-    private int countOfferNum(Long postId) {
-        return offerRepository.findByPost_PostId(postId).size();
+        return posts.stream()
+                .map(PostThumbnailDto::fromEntity).toList();
     }
 
     @Transactional

--- a/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/PostService.java
@@ -20,8 +20,6 @@ import java.util.stream.Collectors;
 import java.util.List;
 
 import static softeer.be33ma3.exception.ErrorCode.*;
-import static softeer.be33ma3.service.MemberService.CENTER_TYPE;
-import static softeer.be33ma3.service.MemberService.CLIENT_TYPE;
 import static softeer.be33ma3.utils.StringParser.stringCommaParsing;
 
 @Service
@@ -43,12 +41,12 @@ public class PostService {
         List<String> repairs = stringCommaParsing(repair);
         List<String> tuneUps = stringCommaParsing(tuneUp);
         List<Long> postIds = null;
-        if(member != null && member.getMemberType() == CENTER_TYPE) {   //센터인 경우
+        if(member != null && member.isCenter()) {   //센터인 경우
             Center center = centerRepository.findByMember_MemberId(member.getMemberId()).orElseThrow(() -> new BusinessException(NOT_FOUND_CENTER));
             postIds = postPerCenterRepository.findPostIdsByCenterId(center.getCenterId());
         }
         Long writerId = null;
-        if(Boolean.TRUE.equals(mine) && member != null && member.getMemberType() == CLIENT_TYPE) {
+        if(Boolean.TRUE.equals(mine) && member != null && member.isClient()) {
             writerId = member.getMemberId();
         }
         List<Post> posts = postRepository.findAllByConditions(writerId, done, regions, repairs, tuneUps, postIds);
@@ -63,7 +61,7 @@ public class PostService {
 
     @Transactional
     public Long createPost(Member currentMember, PostCreateDto postCreateDto, List<MultipartFile> multipartFiles) {
-        if(currentMember.getMemberType() == CENTER_TYPE){   //센터인 경우 글 작성 불가능
+        if(currentMember.isCenter()){   //센터인 경우 글 작성 불가능
             throw new BusinessException(POST_CREATION_DISABLED);
         }
         Region region = getRegion(postCreateDto.getLocation()); //지역 찾기
@@ -138,7 +136,7 @@ public class PostService {
     // 멤버 정보를 이용하여 견적을 작성한 이력이 있는 서비스 센터일 경우 작성한 견적 반환
     // 해당사항 없을 경우 null 반환
     private OfferDetailDto getCenterOffer(Long postId, Member member) {
-        if(member == null || member.getMemberType() == CLIENT_TYPE)
+        if(member == null || member.isClient())
             return null;
         // 해당 게시글에 해당 센터가 작성한 견적 찾기
         Optional<Offer> offer = offerRepository.findByPost_PostIdAndCenter_MemberId(postId, member.getMemberId());

--- a/33ma3/src/main/java/softeer/be33ma3/service/ReviewService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/ReviewService.java
@@ -14,7 +14,6 @@ import softeer.be33ma3.exception.BusinessException;
 import softeer.be33ma3.repository.MemberRepository;
 import softeer.be33ma3.repository.OfferRepository;
 import softeer.be33ma3.repository.post.PostRepository;
-import softeer.be33ma3.repository.review.ReviewCustomRepository;
 import softeer.be33ma3.repository.review.ReviewRepository;
 
 import java.util.ArrayList;
@@ -30,7 +29,6 @@ public class ReviewService {
     private final ReviewRepository reviewRepository;
     private final PostRepository postRepository;
     private final OfferRepository offerRepository;
-    private final ReviewCustomRepository reviewCustomRepository;
     private final MemberRepository memberRepository;
 
     // 리뷰 생성하기
@@ -69,7 +67,7 @@ public class ReviewService {
     }
 
     public List<ShowAllReviewDto> showAllReview() {    //전체 리뷰 조회
-        return reviewCustomRepository.findReviewGroupByCenter();
+        return reviewRepository.findReviewGroupByCenter();
     }
 
     public ShowCenterReviewsDto showOneCenterReviews(Long centerId) {   //특정 센터 리뷰 조회

--- a/33ma3/src/main/java/softeer/be33ma3/service/ReviewService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/ReviewService.java
@@ -74,7 +74,7 @@ public class ReviewService {
         List<OneReviewDto> oneReviewDtos = new ArrayList<>();
         double totalScore = 0.0;
         Member center = memberRepository.findById(centerId).orElseThrow(() -> new BusinessException(NOT_FOUND_CENTER));
-        List<Review> reviews = reviewRepository.findReviewsByCenterIdOrderByScore(center.getMemberId());
+        List<Review> reviews = reviewRepository.findReviewsByCenterIdOrderByScore(centerId);
 
         for (Review review : reviews) {
             totalScore += review.getScore();

--- a/33ma3/src/main/java/softeer/be33ma3/service/SchedulingService.java
+++ b/33ma3/src/main/java/softeer/be33ma3/service/SchedulingService.java
@@ -8,7 +8,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import softeer.be33ma3.domain.Post;
 import softeer.be33ma3.repository.post.PostRepository;
-import softeer.be33ma3.websocket.WebSocketHandler;
 import softeer.be33ma3.websocket.WebSocketService;
 
 import java.time.LocalDateTime;

--- a/33ma3/src/test/java/softeer/be33ma3/repository/ChatMessageRepositoryTest.java
+++ b/33ma3/src/test/java/softeer/be33ma3/repository/ChatMessageRepositoryTest.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import softeer.be33ma3.domain.*;
+import softeer.be33ma3.repository.Chat.ChatMessageRepository;
 
 import java.util.List;
 

--- a/33ma3/src/test/java/softeer/be33ma3/repository/ChatMessageRoomRepositoryTest.java
+++ b/33ma3/src/test/java/softeer/be33ma3/repository/ChatMessageRoomRepositoryTest.java
@@ -8,15 +8,16 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import softeer.be33ma3.domain.ChatRoom;
 import softeer.be33ma3.domain.Member;
+import softeer.be33ma3.repository.Chat.ChatMessageRoomRepository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 
 @SpringBootTest
 @ActiveProfiles("test")
-class ChatRoomRepositoryTest {
+class ChatMessageRoomRepositoryTest {
     @Autowired private MemberRepository memberRepository;
-    @Autowired private ChatRoomRepository chatRoomRepository;
+    @Autowired private ChatMessageRoomRepository chatRoomRepository;
 
     @AfterEach
     void tearDown() {

--- a/33ma3/src/test/java/softeer/be33ma3/service/ChatServiceTest.java
+++ b/33ma3/src/test/java/softeer/be33ma3/service/ChatServiceTest.java
@@ -12,6 +12,7 @@ import softeer.be33ma3.domain.Member;
 import softeer.be33ma3.domain.Post;
 import softeer.be33ma3.dto.request.PostCreateDto;
 import softeer.be33ma3.repository.*;
+import softeer.be33ma3.repository.Chat.ChatMessageRepository;
 import softeer.be33ma3.repository.post.PostRepository;
 
 import java.util.ArrayList;
@@ -24,9 +25,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ChatServiceTest {
     @Autowired ChatService chatService;
     @Autowired MemberRepository memberRepository;
-    @Autowired ChatRoomRepository chatRoomRepository;
+    @Autowired
+    ChatRoomRepository chatRoomRepository;
     @Autowired PostRepository postRepository;
-    @Autowired ChatMessageRepository chatMessageRepository;
+    @Autowired
+    ChatMessageRepository chatMessageRepository;
 
     @AfterEach
     void tearDown() {


### PR DESCRIPTION

## 구현 내용
- [x] 연관관계 지연로딩 설정
- [x] 센터, 클라이언트 판별 member 도메인 내부에서 진행하도록 변경
- [x] postService에서 문자열 파싱하는 부분 디티오 내부에서 하도록 수정
- [x] 챗 서비스 내부의 getChatDto에서 필요한 정보만 가져오도록 수정
- [x] 게시글과 오퍼를 양방향 관계로 설정해서 게시글에 달린 offer를 가져올때 조인 쿼리가 나가지 않도록 변경

## 고민 사항
- 쿼리를 더 개선하고 싶은데 방법이 떠오르지 않는다... 최대한 필요한 정보만 뽑아오려고 노력했다~
- 기존에 memberServie 내부에서 memberType을 상수로 선언하여 다른 모든 서비스에서도 해당 상수를 사용했었는데 member 도메인 내부에서 판별하도록 하여 다른 서비스의 상수를 사용하지 않도록 했다~

## 기타
